### PR TITLE
Content type can be overridden using header HCA-Content-Type

### DIFF
--- a/staging/api_server/area.py
+++ b/staging/api_server/area.py
@@ -43,7 +43,8 @@ def unlock(staging_area_id: str):
 @require_authenticated
 def put_file(staging_area_id: str, filename: str, body: str):
     staging_area = _load_staging_area(staging_area_id)
-    content_type = connexion.request.headers['Content-Type']
+    headers = connexion.request.headers
+    content_type = headers['HCA-Content-Type'] if 'HCA-Content-Type' in headers else headers['Content-Type']
     fileinfo = staging_area.store_file(filename, content=body, content_type=content_type)
     return fileinfo, requests.codes.created
 


### PR DESCRIPTION
I'm not really sure about this change.  It feels like a hack to work around the fact that Chalice/Connexion/Flask are being bitchy about Content-Type.  I am digging into those tools to try debug their Content-Type handling.