### PR TITLE
remove root handlers and use get_logger for all calls

### DIFF
--- a/upload/common/logging.py
+++ b/upload/common/logging.py
@@ -12,6 +12,7 @@ def get_logger(name):
                                   datefmt="%Y-%m-%dT%H:%M:%S%z")
     ch.setFormatter(formatter)
     logger = logging.getLogger(name)
+    logger.handlers = []
     logger.addHandler(ch)
     logger.setLevel(logging.DEBUG)
     return logger


### PR DESCRIPTION
This PR creates all loggers from get_logger in logging module in common. Also based on forum research  at https://forum.serverless.com/t/python-lambda-logging-duplication-workaround/1585, it resets the root handlers to an empty list before adding the StreamHandler. 

I ran make test locally and the 26 tests passed. Let me know if there is something else I should be doing before creating PRs into the upload service.