### PR TITLE
Retry attempts to communicate with AWS Batch with exponential bacoff

### DIFF
--- a/tests/unit/common/test_retry.py
+++ b/tests/unit/common/test_retry.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import patch
+
+from upload.common.retry import Retry
+
+call_count = 0
+
+
+class Exception1(RuntimeError):
+    pass
+
+
+class Exception2(RuntimeError):
+    pass
+
+
+def raise_a_series_of_different_exceptions():
+    global call_count
+    call_count += 1
+    if call_count % 2 == 1:
+        raise Exception1()
+    else:
+        raise Exception2()
+
+
+class TestRetry(unittest.TestCase):
+
+    def setUp(self):
+        global call_count
+        call_count = 0
+
+    @staticmethod
+    def _ignore_exception1(e):
+        return e.__class__ == Exception1
+
+    @patch('upload.common.retry.Retry.EXPONENTIAL_BACKOFF_FACTOR', 0.0001)  # Speed things up
+    def test_if_ignoring_all_exceptions_then_we_hit_max_attempts(self):
+        with self.assertRaises(Exception2):
+            Retry(max_attempts=4).retry(raise_a_series_of_different_exceptions)
+        self.assertEqual(4, call_count)
+
+    @patch('upload.common.retry.Retry.EXPONENTIAL_BACKOFF_FACTOR', 0.0001)  # Speed things up
+    def test_if_ignoring_exception1_it_is_swallowed_but_exception2_bubbles_up(self):
+        with self.assertRaises(Exception2):
+            Retry(ignore_exceptions_func=self._ignore_exception1).retry(raise_a_series_of_different_exceptions)
+        self.assertEqual(2, call_count)

--- a/upload/common/retry.py
+++ b/upload/common/retry.py
@@ -1,0 +1,58 @@
+import logging
+import time
+
+import botocore
+
+logger = logging.getLogger(__name__)
+
+
+class Retry:
+
+    EXPONENTIAL_BACKOFF_FACTOR = 1.618
+
+    def __init__(self, max_attempts=None, ignore_exceptions_func=None):
+        self.start_time = None
+        self.attempt_number = 0
+        self.backoff_seconds = 1.0
+        self.max_attempts = max_attempts
+        self.ignore_exceptions_matcher = ignore_exceptions_func
+
+    def retry(self, func, *args, **kwargs):
+        self.start_time = time.time()
+        while True:
+            try:
+                self.attempt_number += 1
+                retval = func(*args, **kwargs)
+                if self.attempt_number > 1:
+                    logger.debug("Function {func} attempt {attempt} succeeded after {duration} seconds total".format(
+                        func=func, attempt=self.attempt_number, duration=int(time.time() - self.start_time)
+                    ))
+                return retval
+            except Exception as e:
+                logger.debug(f"Function {func} attempt {self.attempt_number} failed ({e.__class__})")
+                if self.max_attempts and self.attempt_number >= self.max_attempts:
+                    raise e
+                if self.ignore_exceptions_matcher:  # Ignore some exceptions
+                    if self.ignore_exceptions_matcher(e):
+                        logger.debug(f"Ignoring {e}")
+                    else:
+                        raise e
+                else:  # Ignore all exceptions
+                    pass
+                self._back_off()
+
+    def _back_off(self):
+        time.sleep(self.backoff_seconds)
+        self.backoff_seconds = min(30.0, self.backoff_seconds * self.EXPONENTIAL_BACKOFF_FACTOR)
+
+
+def retry_on_aws_too_many_requests(func):
+
+    def ingore_exceptions_matcher(e):
+        return e.__class__ == botocore.exceptions.ClientError and \
+            e.response['Error']['Code'] == 'TooManyRequestsException'
+
+    def wrapper(*args, **kwargs):
+        return Retry(ignore_exceptions_func=ingore_exceptions_matcher, max_attempts=20).retry(func, *args, **kwargs)
+
+    return wrapper

--- a/upload/lambdas/api_server/validation_scheduler.py
+++ b/upload/lambdas/api_server/validation_scheduler.py
@@ -7,6 +7,7 @@ import boto3
 
 from ...common.uploaded_file import UploadedFile
 from ...common.batch import JobDefinition
+from ...common.retry import retry_on_aws_too_many_requests
 from ...common.validation_event import UploadedFileValidationEvent
 from ...common.upload_config import UploadConfig
 
@@ -52,6 +53,7 @@ class ValidationScheduler:
             job_defn.create(job_role_arn=self.config.validation_job_role_arn)
         return job_defn
 
+    @retry_on_aws_too_many_requests
     def _enqueue_batch_job(self, job_defn, command, environment):
         job_name = "-".join(["validation", os.environ['DEPLOYMENT_STAGE'], self.file.upload_area.uuid, self.file.name])
         job_name = re.sub(self.JOB_NAME_ALLOWABLE_CHARS, "", job_name)[0:128]


### PR DESCRIPTION
using decorator @retry_on_aws_too_many_attempts
which wraps logic in class Retry

Note this retry functionality is similar to the library tenacity.  I tried that and their logging sucks, so wrote this simple one instead.