### PR TITLE
IAM-Not: get temporary aws credentials on demand

### DIFF
--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -26,7 +26,7 @@ paths:
       summary: Create an Upload Area
       operationId: upload.lambdas.api_server.v1.area.create
       description: |
-        Create an Upload Area.
+        Create an Upload Area. This endpoint is idempotent and can be called for an existing upload area.
       tags:
         - For Ingestion Service Use Only
       security:
@@ -56,10 +56,6 @@ paths:
               - uri
         401:
           description: Unrecognized Api-Key.
-          schema:
-            $ref: '#/definitions/Error'
-        409:
-          description: An upload area with that ID already exists.
           schema:
             $ref: '#/definitions/Error'
         default:

--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -27,7 +27,6 @@ paths:
       operationId: upload.lambdas.api_server.v1.area.create
       description: |
         Create an Upload Area.
-        This action takes approximately 15 seconds to complete.
       tags:
         - For Ingestion Service Use Only
       security:
@@ -169,7 +168,6 @@ paths:
       operationId: upload.lambdas.api_server.v1.area.lock
       description: |
         Lock an Upload area so that submitters may not add/delete/rename files in it.
-        This action takes approximately 15 seconds to complete.
       tags:
         - For Ingestion Service Use Only
       security:
@@ -202,7 +200,6 @@ paths:
       operationId: upload.lambdas.api_server.v1.area.unlock
       description: |
         Unlock an Upload area so that submitters may add/delete/rename files in it.
-        This action takes approximately 15 seconds to complete.
       tags:
         - For Ingestion Service Use Only
       security:

--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -50,11 +50,11 @@ paths:
           schema:
             type: object
             properties:
-              urn:
+              uri:
                 type: string
-                description: URN of the form "dcp:upl:aws:<upload-area-id>:<encoded-credentials>".
+                description: URI describing the location of the upload area.
             required:
-              - urn
+              - uri
         401:
           description: Unrecognized Api-Key.
           schema:
@@ -132,6 +132,31 @@ paths:
           description: Could not find an upload area with that ID.
           schema:
             $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /v1/area/{upload_area_id}/credentials:
+
+    post:
+      summary: Create credentials for access to this upload area
+      operationId: upload.lambdas.api_server.v1.area.credentials
+      description: |
+        Request a set of AWS access credentials that will allow write/list access to this upload area.
+      tags:
+        - All
+      parameters:
+        - name: upload_area_id
+          in: path
+          description: A RFC4122-compliant ID for the upload area.
+          required: true
+          type: string
+      responses:
+        201:
+          description: Credentials were created.
+        423:
+          description: This upload area is currently locked.  No credentials can be issued.
         default:
           description: Unexpected error
           schema:

--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -33,9 +33,11 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
   vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"

--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -19,10 +19,16 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-  bucket_name_prefix = "${var.bucket_name_prefix}"
 
   vpc_id = "${var.vpc_id}"
   vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+
+  // S3
+  bucket_name_prefix = "${var.bucket_name_prefix}"
+
+  // API Lambda
+  upload_api_fqdn = "${var.upload_api_fqdn}"
+  ingest_api_key = "${var.ingest_api_key}"
 
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
@@ -36,4 +42,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+
+  // DCP Ingest
+  ingest_amqp_server = "${var.ingest_amqp_server}"
 }

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -14,9 +14,11 @@ ingest_api_key = "xxxxxxxxxxxxxxxxxxxx"
 // Validation Batch infrastructure.
 validation_cluster_ec2_key_pair = "my-ec2-keypair"
 validation_cluster_ami_id = "ami-xxxxxxxx"
+validation_cluster_min_vcpus = 0
 
 // Checksumming Batch infrastructure.
-validation_cluster_ec2_key_pair = "my-ec2-keypair"
+csum_cluster_ec2_key_pair = "my-ec2-keypair"
+csum_cluster_min_vcpus = 0
 
 // Database
 vpc_rds_security_group_id = "sg-xxxxxxxx"

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -1,8 +1,15 @@
+deployment_stage = "XXX"
+
 // The VPC in which you want your Batch infrastructure deployed.
 vpc_id = "vpc-xxxxxxxx"
 vpc_default_security_group_id = "sg-xxxxxxxx"
 
+// S3
 bucket_name_prefix = "org-humancellatlas-upload-"
+
+// API Lambda
+upload_api_fqdn = "upload.<deployment_stage>.data.humancellatlas.org"
+ingest_api_key = "xxxxxxxxxxxxxxxxxxxx"
 
 // Validation Batch infrastructure.
 validation_cluster_ec2_key_pair = "my-ec2-keypair"
@@ -16,3 +23,6 @@ vpc_rds_security_group_id = "sg-xxxxxxxx"
 db_username = "xxxxxxxx"
 db_password = "xxxxxxxxxxxxx"
 db_instance_count = 1
+
+// DCP Ingest
+ingest_amqp_server = "amqp.ingest.<deployment_stage>.data.humancellatlas.org"

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -31,7 +31,13 @@ variable "validation_cluster_ec2_key_pair" {
 variable "validation_cluster_ami_id" {
   type = "string"
 }
+variable "validation_cluster_min_vcpus" {
+  type = "string"
+}
 variable "csum_cluster_ec2_key_pair" {
+  type = "string"
+}
+variable "csum_cluster_min_vcpus" {
   type = "string"
 }
 

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -1,27 +1,41 @@
 variable "deployment_stage" {
   type = "string"
-  default = "dev"
-}
-variable "bucket_name_prefix" {
-  type = "string"
 }
 variable "vpc_id" {
   type = "string"
 }
-
 variable "vpc_default_security_group_id" {
   type = "string"
 }
-variable "validation_cluster_ec2_key_pair" {
+
+// S3
+
+variable "bucket_name_prefix" {
   type = "string"
 }
 
+// API Lambda
+
+variable "upload_api_fqdn" {
+  type = "string"
+}
+variable "ingest_api_key" {
+  type = "string"
+}
+
+// Batch
+
+variable "validation_cluster_ec2_key_pair" {
+  type = "string"
+}
 variable "validation_cluster_ami_id" {
   type = "string"
 }
 variable "csum_cluster_ec2_key_pair" {
   type = "string"
 }
+
+// RDS
 
 variable "vpc_rds_security_group_id" {
   type = "string"
@@ -33,5 +47,11 @@ variable "db_password" {
   type = "string"
 }
 variable "db_instance_count" {
+  type = "string"
+}
+
+// DCP Ingest
+
+variable "ingest_amqp_server" {
   type = "string"
 }

--- a/terraform/envs/integration/main.tf
+++ b/terraform/envs/integration/main.tf
@@ -34,9 +34,11 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
   vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"

--- a/terraform/envs/integration/main.tf
+++ b/terraform/envs/integration/main.tf
@@ -19,10 +19,17 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-  bucket_name_prefix = "${var.bucket_name_prefix}"
 
   vpc_id = "${var.vpc_id}"
   vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+
+    // S3
+  bucket_name_prefix = "${var.bucket_name_prefix}"
+
+  // API Lambda
+
+  upload_api_fqdn = "${var.upload_api_fqdn}"
+  ingest_api_key = "${var.ingest_api_key}"
 
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
@@ -36,4 +43,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+
+  // DCP Ingest
+  ingest_amqp_server = "${var.ingest_amqp_server}"
 }

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -33,9 +33,11 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
   vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -19,10 +19,16 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-  bucket_name_prefix = "${var.bucket_name_prefix}"
 
   vpc_id = "${var.vpc_id}"
   vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+
+  // S3
+  bucket_name_prefix = "${var.bucket_name_prefix}"
+
+  // API Lambda
+  upload_api_fqdn = "${var.upload_api_fqdn}"
+  ingest_api_key = "${var.ingest_api_key}"
 
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
@@ -36,4 +42,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+
+  // DCP Ingest
+  ingest_amqp_server = "${var.ingest_amqp_server}"
 }

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -33,9 +33,11 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
   vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -19,10 +19,16 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-  bucket_name_prefix = "${var.bucket_name_prefix}"
 
   vpc_id = "${var.vpc_id}"
   vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+
+  // S3
+  bucket_name_prefix = "${var.bucket_name_prefix}"
+
+  // API Lambda
+  upload_api_fqdn = "${var.upload_api_fqdn}"
+  ingest_api_key = "${var.ingest_api_key}"
 
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
@@ -36,4 +42,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+
+  // DCP Ingest
+  ingest_amqp_server = "${var.ingest_amqp_server}"
 }

--- a/terraform/modules/upload-service/api_lambda.tf
+++ b/terraform/modules/upload-service/api_lambda.tf
@@ -1,0 +1,121 @@
+resource "aws_iam_role" "upload_api_lambda" {
+  name = "upload-api-${var.deployment_stage}"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "upload_api_lambda" {
+  name = "upload-api-${var.deployment_stage}"
+  role = "${aws_iam_role.upload_api_lambda.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.bucket_name}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetObjectTagging",
+        "s3:PutObjectTagging"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.bucket_name}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetUser",
+        "iam:CreateUser",
+        "iam:DeleteUser",
+        "iam:PutUserPolicy",
+        "iam:DeleteUserPolicy",
+        "iam:ListUserPolicies",
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:ListAccessKeys",
+        "iam:PassRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::${local.account_id}:role/dcp-upload-*",
+        "arn:aws:iam::${local.account_id}:user/upload-*",
+        "arn:aws:iam::${local.account_id}:policy/dcp-upload-*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "batch:Describe*",
+        "batch:RegisterJobDefinition",
+        "batch:SubmitJob"
+      ],
+      "Resource": [
+        "arn:aws:batch:*:${local.account_id}:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:us-east-1:${local.account_id}:secret:dcp/upload/${var.deployment_stage}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "upload_api_lambda" {
+  function_name    = "upload-api-${var.deployment_stage}"
+  role             = "arn:aws:iam::861229788715:role/upload-api-dev"
+  handler          = "app.app"
+  runtime          = "python3.6"
+  memory_size      = 512
+  timeout          = 300
+
+  environment {
+    variables = {
+      DEPLOYMENT_STAGE = "${var.deployment_stage}",
+      INGEST_API_KEY = "${var.ingest_api_key}",
+      INGEST_AMQP_SERVER = "${var.ingest_amqp_server}",
+      API_HOST = "${var.upload_api_fqdn}"
+    }
+  }
+}

--- a/terraform/modules/upload-service/bucket.tf
+++ b/terraform/modules/upload-service/bucket.tf
@@ -1,7 +1,67 @@
 resource "aws_s3_bucket" "upload_areas_bucket" {
-  bucket = "${var.bucket_name_prefix}${var.deployment_stage}"
+  bucket = "${local.bucket_name}"
   acl = "private"
   force_destroy = "false"
   acceleration_status = "Enabled"
 }
 
+resource "aws_iam_policy" "upload_areas_submitter_access" {
+  name = "dcp-upload-areas-submitter-access-${var.deployment_stage}"
+  // Note that this policy creates very broad access, to all upload areas in the bucket.
+  // It will be narrowed down to a single upload area during the AssumeRole process.
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:PutObjectTagging"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${aws_s3_bucket.upload_areas_bucket.bucket}/*"
+ ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${aws_s3_bucket.upload_areas_bucket.bucket}"
+            ]
+        }
+    ]
+}
+POLICY
+}
+
+locals {
+  # The ARN of the principal of the running API Lambda
+  api_lambda_principal_arn = "arn:aws:sts::${local.account_id}:assumed-role/${aws_iam_role.upload_api_lambda.name}/${aws_lambda_function.upload_api_lambda.function_name}"
+}
+
+resource "aws_iam_role" "upload_submitter" {
+  name = "dcp-upload-submitter-${var.deployment_stage}"
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "${local.api_lambda_principal_arn}"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "upload_submitter" {
+  role = "${aws_iam_role.upload_submitter.name}"
+  policy_arn = "${aws_iam_policy.upload_areas_submitter_access.arn}"
+}

--- a/terraform/modules/upload-service/checksumming.tf
+++ b/terraform/modules/upload-service/checksumming.tf
@@ -7,8 +7,10 @@ resource "aws_batch_compute_environment" "csum_compute_env" {
     bid_percentage = 100
     spot_iam_fleet_role = "${aws_iam_role.AmazonEC2SpotFleetRole.arn}"
     max_vcpus = 64
-    min_vcpus = 0
-    desired_vcpus = 0
+    min_vcpus = "${var.csum_cluster_min_vcpus}"
+    // We set desired vcpus to min vcpus, as that is the resting state in AWS
+    // and otherwise we get a change on every apply.
+    desired_vcpus = "${var.csum_cluster_min_vcpus}"
     instance_type = [
       "m4"
     ]

--- a/terraform/modules/upload-service/main.tf
+++ b/terraform/modules/upload-service/main.tf
@@ -1,3 +1,8 @@
+locals {
+  bucket_name = "${var.bucket_name_prefix}${var.deployment_stage}"
+  account_id = "${data.aws_caller_identity.current.account_id}"
+}
+
 module "upload-service-database" {
   source = "../../modules/database"
   deployment_stage = "${var.deployment_stage}"

--- a/terraform/modules/upload-service/secrets.tf
+++ b/terraform/modules/upload-service/secrets.tf
@@ -12,7 +12,8 @@ resource "aws_secretsmanager_secret_version" "secrets" {
   "validation_job_q_arn": "${aws_batch_job_queue.validation_job_q.arn}",
   "validation_job_role_arn": "${aws_iam_role.validation_job_role.arn}",
   "csum_job_q_arn": "${aws_batch_job_queue.csum_job_q.arn}",
-  "csum_job_role_arn": "${aws_iam_role.csum_job_role.arn}"
+  "csum_job_role_arn": "${aws_iam_role.csum_job_role.arn}",
+  "upload_submitter_role_arn": "${aws_iam_role.upload_submitter.arn}"
 }
 SECRETS_JSON
 }

--- a/terraform/modules/upload-service/validation.tf
+++ b/terraform/modules/upload-service/validation.tf
@@ -7,8 +7,10 @@ resource "aws_batch_compute_environment" "validation_compute_env" {
     bid_percentage = 100
     spot_iam_fleet_role = "${aws_iam_role.AmazonEC2SpotFleetRole.arn}"
     max_vcpus = 256
-    min_vcpus = 0
-    desired_vcpus = 0
+    min_vcpus = "${var.validation_cluster_min_vcpus}"
+    // We set desired vcpus to min vcpus, as that is the resting state in AWS
+    // and otherwise we get a change on every apply.
+    desired_vcpus = "${var.validation_cluster_min_vcpus}"
     instance_type = [
       "m4"
     ]

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -1,11 +1,3 @@
-variable "deployment_stage" {
-  type = "string"
-}
-
-variable "bucket_name_prefix" {
-  type = "string"
-}
-
 variable "vpc_id" {
   type = "string"
 }
@@ -13,6 +5,27 @@ variable "vpc_id" {
 variable "vpc_default_security_group_id" {
   type = "string"
 }
+
+variable "deployment_stage" {
+  type = "string"
+}
+
+// S3
+
+variable "bucket_name_prefix" {
+  type = "string"
+}
+
+// API Lambda
+
+variable "upload_api_fqdn" {
+  type = "string"
+}
+variable "ingest_api_key" {
+  type = "string"
+}
+
+// Batch
 
 variable "validation_cluster_ec2_key_pair" {
   type = "string"
@@ -43,6 +56,12 @@ variable "db_password" {
 variable "db_instance_count" {
   type = "string"
   default = 2
+}
+
+# DCP Ingest
+
+variable "ingest_amqp_server" {
+  type = "string"
 }
 
 # Data Sources

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -30,12 +30,17 @@ variable "ingest_api_key" {
 variable "validation_cluster_ec2_key_pair" {
   type = "string"
 }
-
 variable "validation_cluster_ami_id" {
+  type = "string"
+}
+variable "validation_cluster_min_vcpus" {
   type = "string"
 }
 
 variable "csum_cluster_ec2_key_pair" {
+  type = "string"
+}
+variable "csum_cluster_min_vcpus" {
   type = "string"
 }
 

--- a/tests/unit/common/test_checksum.py
+++ b/tests/unit/common/test_checksum.py
@@ -31,7 +31,7 @@ class TestUploadedFileChecksummer(UploadTestCaseUsingMockAWS):
 
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.create()
+        self.upload_area.update_or_create()
 
         self.checksum_id = str(uuid.uuid4())
         self.job_id = str(uuid.uuid4())

--- a/tests/unit/common/test_checksum.py
+++ b/tests/unit/common/test_checksum.py
@@ -1,5 +1,4 @@
 import uuid
-from unittest.mock import patch
 
 import boto3
 
@@ -13,7 +12,6 @@ from upload.common.upload_config import UploadConfig
 
 class TestUploadedFileChecksummer(UploadTestCaseUsingMockAWS):
 
-    @patch('upload.common.upload_area.UploadArea.IAM_SETTLE_TIME_SEC', 0)
     def setUp(self):
         super().setUp()
         # Config

--- a/tests/unit/common/test_uploaded_file.py
+++ b/tests/unit/common/test_uploaded_file.py
@@ -23,7 +23,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
 
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.create()
+        self.upload_area.update_or_create()
 
     def tearDown(self):
         super().tearDown()

--- a/tests/unit/common/test_uploaded_file.py
+++ b/tests/unit/common/test_uploaded_file.py
@@ -1,5 +1,4 @@
 import uuid
-from unittest.mock import patch
 
 import boto3
 
@@ -12,7 +11,6 @@ from upload.common.uploaded_file import UploadedFile
 
 class TestUploadedFile(UploadTestCaseUsingMockAWS):
 
-    @patch('upload.common.upload_area.UploadArea.IAM_SETTLE_TIME_SEC', 0)
     def setUp(self):
         super().setUp()
         # Config

--- a/tests/unit/docker_images/test_checksummer.py
+++ b/tests/unit/docker_images/test_checksummer.py
@@ -38,7 +38,7 @@ class TestChecksummerDockerImage(UploadTestCaseUsingMockAWS):
         self.upload_bucket.create()
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.create()
+        self.upload_area.update_or_create()
 
     def tearDown(self):
         super().tearDown()

--- a/tests/unit/docker_images/test_checksummer.py
+++ b/tests/unit/docker_images/test_checksummer.py
@@ -17,7 +17,6 @@ from upload.common.upload_config import UploadConfig
 
 class TestChecksummerDockerImage(UploadTestCaseUsingMockAWS):
 
-    @patch('upload.common.upload_area.UploadArea.IAM_SETTLE_TIME_SEC', 0)
     def setUp(self):
         super().setUp()
         UploadConfig.use_env = True

--- a/tests/unit/lambdas/api_server/__init__.py
+++ b/tests/unit/lambdas/api_server/__init__.py
@@ -1,11 +1,14 @@
-import connexion
+import os
 import yaml
+
+import connexion
 
 
 def client_for_test_api_server():
     flask_app = connexion.FlaskApp(__name__)
 
-    with open('config/upload-api.yml', mode='rb') as swagger_yaml:
+    swagger_yaml_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../config/upload-api.yml'))
+    with open(swagger_yaml_path, mode='rb') as swagger_yaml:
         contents = swagger_yaml.read()
         swagger_string = contents.decode()
         specification = yaml.safe_load(swagger_string)  # type: dict

--- a/tests/unit/lambdas/api_server/test_area.py
+++ b/tests/unit/lambdas/api_server/test_area.py
@@ -246,8 +246,16 @@ class TestAreaApi(UploadTestCaseUsingMockAWS):
 
         response = self.client.post(f"/v1/area/{area_id}", headers=self.authentication_header)
 
-        self.assertEqual(409, response.status_code)
-        self.assertEqual('application/problem+json', response.content_type)
+        self.assertEqual(201, response.status_code)
+        body = json.loads(response.data)
+        self.assertEqual(
+            {'uri': f"s3://{self.config.bucket_name}/{area_id}/"},
+            body)
+
+        record = get_pg_record("upload_area", area_id)
+        self.assertEqual(area_id, record["id"])
+        self.assertEqual(self.config.bucket_name, record["bucket_name"])
+        self.assertEqual("UNLOCKED", record["status"])
 
     def test_credentials_with_non_existent_upload_area(self):
         area_id = str(uuid.uuid4())

--- a/tests/unit/lambdas/api_server/test_upload_api_client.py
+++ b/tests/unit/lambdas/api_server/test_upload_api_client.py
@@ -53,7 +53,6 @@ class TestDatabase(UploadTestCaseUsingMockAWS):
         super().tearDown()
         self.environmentor.exit()
 
-    @patch('upload.common.upload_area.UploadArea.IAM_SETTLE_TIME_SEC', 0)
     def _create_area(self):
         area_id = str(uuid.uuid4())
         self.client.post(f"/v1/area/{area_id}", headers=self.authentication_header)

--- a/tests/unit/lambdas/test_checksum_daemon.py
+++ b/tests/unit/lambdas/test_checksum_daemon.py
@@ -46,7 +46,7 @@ class TestChecksumDaemon(UploadTestCaseUsingMockAWS):
         # Upload area
         self.area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.area_id)
-        self.upload_area.create()
+        self.upload_area.update_or_create()
         # daemon
         context = Mock()
         self.daemon = ChecksumDaemon(context)

--- a/tests/unit/lambdas/test_checksum_daemon.py
+++ b/tests/unit/lambdas/test_checksum_daemon.py
@@ -22,7 +22,6 @@ from upload.lambdas.checksum_daemon import ChecksumDaemon  # noqa
 
 class TestChecksumDaemon(UploadTestCaseUsingMockAWS):
 
-    @patch('upload.common.upload_area.UploadArea.IAM_SETTLE_TIME_SEC', 0)
     def setUp(self):
         super().setUp()
         # Config

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -1,10 +1,6 @@
-import base64
-import json
 import os
-import time
 import boto3
 import uuid
-from botocore.exceptions import ClientError
 
 from dcplib.media_types import DcpMediaType
 
@@ -14,17 +10,12 @@ from .checksum_event import UploadedFileChecksumEvent
 from .exceptions import UploadException
 from .upload_config import UploadConfig
 if not os.environ.get("CONTAINER"):
-    from .database import create_pg_record, update_pg_record
+    from .database import get_pg_record, create_pg_record, update_pg_record
 
 s3 = boto3.resource('s3')
-iam = boto3.resource('iam')
 
 
 class UploadArea:
-
-    USER_NAME_TEMPLATE = "upload-{deployment_stage}-user-{uuid}"
-    ACCESS_POLICY_NAME_TEMPLATE = "upload-{uuid}"
-    IAM_SETTLE_TIME_SEC = 15
 
     def __init__(self, uuid):
         self.uuid = uuid
@@ -32,10 +23,7 @@ class UploadArea:
         self.config = UploadConfig()
         self.key_prefix = f"{self.uuid}/"
         self.key_prefix_length = len(self.key_prefix)
-        self.user_name = self.USER_NAME_TEMPLATE.format(deployment_stage=self._deployment_stage, uuid=uuid)
         self._bucket = s3.Bucket(self.bucket_name)
-        self._user = iam.User(self.user_name)
-        self._credentials = None
 
     @property
     def bucket_name(self):
@@ -46,37 +34,18 @@ class UploadArea:
         return os.environ['DEPLOYMENT_STAGE']
 
     @property
-    def urn(self):
-        encoded_credentials = base64.b64encode(json.dumps(self._credentials).encode('utf8')).decode('utf8')
-        if self._deployment_stage == 'prod':
-            return f"dcp:upl:aws:{self.uuid}:{encoded_credentials}"
-        else:
-            return f"dcp:upl:aws:{self._deployment_stage}:{self.uuid}:{encoded_credentials}"
-
-    @property
-    def access_policy_name(self):
-        return self.ACCESS_POLICY_NAME_TEMPLATE.format(uuid=self.uuid)
+    def uri(self):
+        return f"s3://{self._bucket.name}/{self.key_prefix}"
 
     def create(self):
-        self.status = "CREATING"
-        self._create_record()
-        self._user.create()
-        self._set_access_policy()
-        self._create_credentials()
-        time.sleep(self.IAM_SETTLE_TIME_SEC)
         self.status = "UNLOCKED"
-        self._update_record()
+        self._create_record()
 
     def delete(self):
         # This may need to be offloaded to an async lambda if _empty_bucket() starts taking a long time.
         self.status = "DELETING"
         self._update_record()
         self._empty_upload_area()
-        for access_key in self._user.access_keys.all():
-            access_key.delete()
-        for policy in self._user.policies.all():
-            policy.delete()
-        self._user.delete()
         self.status = "DELETED"
         self._update_record()
 
@@ -122,15 +91,10 @@ class UploadArea:
         return UploadedFile.from_s3_key(self, key)
 
     def is_extant(self) -> bool:
-        # A upload area is a folder, however there is no concept of folder in S3.
-        # The existence of a upload area is the existence of the user who can access that area.
-        try:
-            self._user.load()
+        record = get_pg_record('upload_area', self.uuid)
+        if record and record['status'] != 'DELETED':
             return True
-        except ClientError as e:
-            if e.response['Error']['Code'] != 'NoSuchEntity':
-                raise UploadException(status=500, title="Unexpected Error",
-                                      detail=f"bucket.load() returned {e.response}")
+        else:
             return False
 
     def _file_list(self):
@@ -142,43 +106,6 @@ class UploadArea:
                     file = UploadedFile.from_s3_key(self, o['Key'])
                     file_list.append(file.info())
         return file_list
-
-    def _set_access_policy(self):
-        policy_document = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:PutObject",
-                        "s3:PutObjectTagging"
-                    ],
-                    "Resource": [
-                        f"arn:aws:s3:::{self.bucket_name}/{self.uuid}/*",
-                    ]
-                },
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:ListBucket"
-                    ],
-                    "Resource": [
-                        f"arn:aws:s3:::{self.bucket_name}"
-                    ],
-                    "Condition": {
-                        "StringEquals": {
-                            "s3:prefix": f"{self.uuid}/"
-                        }
-                    }
-                }
-            ]
-        }
-        self._user.create_policy(PolicyName=self.access_policy_name, PolicyDocument=json.dumps(policy_document))
-
-    def _create_credentials(self):
-        credentials = self._user.create_access_key_pair()
-        self._credentials = {'AWS_ACCESS_KEY_ID': credentials.access_key_id,
-                             'AWS_SECRET_ACCESS_KEY': credentials.secret_access_key}
 
     def _empty_upload_area(self):
         paginator = s3.meta.client.get_paginator('list_objects')

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -28,6 +28,7 @@ class UploadArea:
 
     def __init__(self, uuid):
         self.uuid = uuid
+        self.status = None
         self.config = UploadConfig()
         self.key_prefix = f"{self.uuid}/"
         self.key_prefix_length = len(self.key_prefix)
@@ -83,18 +84,10 @@ class UploadArea:
         return {'files': self._file_list()}
 
     def lock(self):
-        self.status = "LOCKING"
-        self._update_record()
-        iam.UserPolicy(self.user_name, self.access_policy_name).delete()
-        time.sleep(self.IAM_SETTLE_TIME_SEC)
         self.status = "LOCKED"
         self._update_record()
 
     def unlock(self):
-        self.status = "UNLOCKING"
-        self._update_record()
-        self._set_access_policy()
-        time.sleep(self.IAM_SETTLE_TIME_SEC)
         self.status = "UNLOCKED"
         self._update_record()
 

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -43,9 +43,12 @@ class UploadArea:
     def uri(self):
         return f"s3://{self._bucket.name}/{self.key_prefix}"
 
-    def create(self):
+    def update_or_create(self):
         self.status = "UNLOCKED"
-        self._create_record()
+        if self._db_record():
+            self._update_record()
+        else:
+            self._create_record()
 
     def credentials(self):
         record = self._db_record()

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -23,6 +23,12 @@ def create(upload_area_id: str):
 
 
 @return_exceptions_as_http_errors
+def credentials(upload_area_id: str):
+    upload_area = _load_upload_area(upload_area_id)
+    return upload_area.credentials(), requests.codes.created
+
+
+@return_exceptions_as_http_errors
 @require_authenticated
 def delete(upload_area_id: str):
     upload_area = _load_upload_area(upload_area_id)

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -18,11 +18,8 @@ logger = get_logger(__name__)
 @require_authenticated
 def create(upload_area_id: str):
     upload_area = UploadArea(upload_area_id)
-    if upload_area.is_extant():
-        raise UploadException(status=requests.codes.conflict, title="Upload Area Already Exists",
-                              detail=f"Upload area {upload_area_id} already exists.")
     upload_area.create()
-    return {'urn': upload_area.urn}, requests.codes.created
+    return {'uri': upload_area.uri}, requests.codes.created
 
 
 @return_exceptions_as_http_errors
@@ -136,7 +133,6 @@ def files_info(upload_area_id: str, body: str):
 
 def _load_upload_area(upload_area_id: str):
     upload_area = UploadArea(upload_area_id)
-
     if not upload_area.is_extant():
         raise UploadException(status=requests.codes.not_found, title="Upload Area Not Found")
     return upload_area

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 @require_authenticated
 def create(upload_area_id: str):
     upload_area = UploadArea(upload_area_id)
-    upload_area.create()
+    upload_area.update_or_create()
     return {'uri': upload_area.uri}, requests.codes.created
 
 


### PR DESCRIPTION
instead of creating an IAM user for each upload area

Described in document: https://docs.google.com/document/d/1JFO75A9OR1gnCT1nYHH5p-vEaf0-TdOtOme3M3b9g3A/edit#

Paired with https://github.com/HumanCellAtlas/dcp-cli/pull/126