### PR TITLE
change create on upload to be idempotent

### DIFF
--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -26,7 +26,7 @@ paths:
       summary: Create an Upload Area
       operationId: upload.lambdas.api_server.v1.area.create
       description: |
-        Create an Upload Area.
+        Create an Upload Area. This endpoint is idempotent and can be called for an existing upload area.
       tags:
         - For Ingestion Service Use Only
       security:
@@ -56,10 +56,6 @@ paths:
               - uri
         401:
           description: Unrecognized Api-Key.
-          schema:
-            $ref: '#/definitions/Error'
-        409:
-          description: An upload area with that ID already exists.
           schema:
             $ref: '#/definitions/Error'
         default:

--- a/tests/unit/common/test_checksum.py
+++ b/tests/unit/common/test_checksum.py
@@ -31,7 +31,7 @@ class TestUploadedFileChecksummer(UploadTestCaseUsingMockAWS):
 
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.get_or_create()
+        self.upload_area.update_or_create()
 
         self.checksum_id = str(uuid.uuid4())
         self.job_id = str(uuid.uuid4())

--- a/tests/unit/common/test_checksum.py
+++ b/tests/unit/common/test_checksum.py
@@ -31,7 +31,7 @@ class TestUploadedFileChecksummer(UploadTestCaseUsingMockAWS):
 
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.create()
+        self.upload_area.get_or_create()
 
         self.checksum_id = str(uuid.uuid4())
         self.job_id = str(uuid.uuid4())

--- a/tests/unit/common/test_uploaded_file.py
+++ b/tests/unit/common/test_uploaded_file.py
@@ -23,7 +23,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
 
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.create()
+        self.upload_area.get_or_create()
 
     def tearDown(self):
         super().tearDown()

--- a/tests/unit/common/test_uploaded_file.py
+++ b/tests/unit/common/test_uploaded_file.py
@@ -23,7 +23,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
 
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.get_or_create()
+        self.upload_area.update_or_create()
 
     def tearDown(self):
         super().tearDown()

--- a/tests/unit/docker_images/test_checksummer.py
+++ b/tests/unit/docker_images/test_checksummer.py
@@ -38,7 +38,7 @@ class TestChecksummerDockerImage(UploadTestCaseUsingMockAWS):
         self.upload_bucket.create()
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.create()
+        self.upload_area.get_or_create()
 
     def tearDown(self):
         super().tearDown()

--- a/tests/unit/docker_images/test_checksummer.py
+++ b/tests/unit/docker_images/test_checksummer.py
@@ -38,7 +38,7 @@ class TestChecksummerDockerImage(UploadTestCaseUsingMockAWS):
         self.upload_bucket.create()
         self.upload_area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.upload_area_id)
-        self.upload_area.get_or_create()
+        self.upload_area.update_or_create()
 
     def tearDown(self):
         super().tearDown()

--- a/tests/unit/lambdas/api_server/test_area.py
+++ b/tests/unit/lambdas/api_server/test_area.py
@@ -246,8 +246,16 @@ class TestAreaApi(UploadTestCaseUsingMockAWS):
 
         response = self.client.post(f"/v1/area/{area_id}", headers=self.authentication_header)
 
-        self.assertEqual(409, response.status_code)
-        self.assertEqual('application/problem+json', response.content_type)
+        self.assertEqual(201, response.status_code)
+        body = json.loads(response.data)
+        self.assertEqual(
+            {'uri': f"s3://{self.config.bucket_name}/{area_id}/"},
+            body)
+
+        record = get_pg_record("upload_area", area_id)
+        self.assertEqual(area_id, record["id"])
+        self.assertEqual(self.config.bucket_name, record["bucket_name"])
+        self.assertEqual("UNLOCKED", record["status"])
 
     def test_credentials_with_non_existent_upload_area(self):
         area_id = str(uuid.uuid4())

--- a/tests/unit/lambdas/test_checksum_daemon.py
+++ b/tests/unit/lambdas/test_checksum_daemon.py
@@ -46,7 +46,7 @@ class TestChecksumDaemon(UploadTestCaseUsingMockAWS):
         # Upload area
         self.area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.area_id)
-        self.upload_area.get_or_create()
+        self.upload_area.update_or_create()
         # daemon
         context = Mock()
         self.daemon = ChecksumDaemon(context)

--- a/tests/unit/lambdas/test_checksum_daemon.py
+++ b/tests/unit/lambdas/test_checksum_daemon.py
@@ -46,7 +46,7 @@ class TestChecksumDaemon(UploadTestCaseUsingMockAWS):
         # Upload area
         self.area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.area_id)
-        self.upload_area.create()
+        self.upload_area.get_or_create()
         # daemon
         context = Mock()
         self.daemon = ChecksumDaemon(context)

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -43,7 +43,7 @@ class UploadArea:
     def uri(self):
         return f"s3://{self._bucket.name}/{self.key_prefix}"
 
-    def get_or_create(self):
+    def update_or_create(self):
         self.status = "UNLOCKED"
         if self._db_record():
             self._update_record()

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -43,9 +43,12 @@ class UploadArea:
     def uri(self):
         return f"s3://{self._bucket.name}/{self.key_prefix}"
 
-    def create(self):
+    def get_or_create(self):
         self.status = "UNLOCKED"
-        self._create_record()
+        if self._db_record():
+            self._update_record()
+        else:
+            self._create_record()
 
     def credentials(self):
         record = self._db_record()

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 @require_authenticated
 def create(upload_area_id: str):
     upload_area = UploadArea(upload_area_id)
-    upload_area.create()
+    upload_area.get_or_create()
     return {'uri': upload_area.uri}, requests.codes.created
 
 

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 @require_authenticated
 def create(upload_area_id: str):
     upload_area = UploadArea(upload_area_id)
-    upload_area.get_or_create()
+    upload_area.update_or_create()
     return {'uri': upload_area.uri}, requests.codes.created
 
 


### PR DESCRIPTION
change upload create endpoint to be idempotent. related to https://app.zenhub.com/workspace/o/humancellatlas/upload-service/issues/87