### PR TITLE
/credentials endpoint returns 1 hour tokens instead of 15 mins

### DIFF
--- a/terraform/modules/upload-service/bucket.tf
+++ b/terraform/modules/upload-service/bucket.tf
@@ -44,6 +44,7 @@ locals {
 
 resource "aws_iam_role" "upload_submitter" {
   name = "dcp-upload-submitter-${var.deployment_stage}"
+  max_session_duration = 3600,
   assume_role_policy = <<POLICY
 {
     "Version": "2012-10-17",

--- a/terraform/modules/upload-service/validation.tf
+++ b/terraform/modules/upload-service/validation.tf
@@ -8,8 +8,10 @@ resource "aws_batch_compute_environment" "validation_compute_env" {
     spot_iam_fleet_role = "${aws_iam_role.AmazonEC2SpotFleetRole.arn}"
     max_vcpus = 256
     min_vcpus = "${var.validation_cluster_min_vcpus}"
-    // We set desired vcpus to min vcpus, as that is the resting state in AWS
-    // and otherwise we get a change on every apply.
+    // You must set desired_vcpus otherwise you get error: "desiredvCpus should be between minvCpus and maxvCpus"
+    // However this is actually not settable in AWS.  It will not let you change it.
+    // So you actually have to find out what the current value is and setit to that!
+    // Here. we try set desired vcpus to min vcpus, as that is the resting state in AWS.
     desired_vcpus = "${var.validation_cluster_min_vcpus}"
     instance_type = [
       "m4"

--- a/tests/unit/lambdas/api_server/test_area.py
+++ b/tests/unit/lambdas/api_server/test_area.py
@@ -343,7 +343,7 @@ class TestAreaApi(UploadTestCaseUsingMockAWS):
         response = self.client.post(f"/v1/area/{area_id}/credentials")
 
         data = json.loads(response.data)
-        self.assertEqual(['AccessKeyId', 'SecretAccessKey', 'SessionToken'], list(data.keys()))
+        self.assertEqual(['AccessKeyId', 'Expiration', 'SecretAccessKey', 'SessionToken'], list(data.keys()))
 
     def test_delete_with_id_of_real_non_empty_upload_area(self):
         area_id = self._create_area()

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -79,12 +79,11 @@ class UploadArea:
         response = sts.assume_role(
             RoleArn=self.config.upload_submitter_role_arn,
             RoleSessionName=self.uuid,
-            DurationSeconds=900,
+            DurationSeconds=3600,
             ExternalId="TBD",
             Policy=policy_json
         )
         creds = response['Credentials']
-        del creds['Expiration']
         return creds
 
     def delete(self):


### PR DESCRIPTION
and also returns the token expiration time too.