### PR TITLE
US-21: [madison] add file size check to validation scheduler

### DIFF
--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -355,6 +355,10 @@ paths:
               validation_id:
                 type: string
                 description: A reference ID for this validation, which will be used later during the callback.
+        400:
+          description: File too large due to 1tb limit for staging files from s3 during validation process
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unrecognized Api-Key.
           schema:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,5 @@ moto >= 1.3.3
 python-dateutil < 2.7.0
 alembic
 psycopg2-binary
+hca
 -r requirements.txt

--- a/tests/unit/common/test_uploaded_file.py
+++ b/tests/unit/common/test_uploaded_file.py
@@ -48,7 +48,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual("file2_content".encode('utf8'),
                          self.upload_bucket.Object(f"{self.upload_area_id}/file2").get()['Body'].read())
 
-    @patch('upload.common.upload_area.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES+1)
+    @patch('upload.common.upload_area.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES + 1)
     def test_check_file_can_be_validated_returns_false_if_file_is_too_large_for_validation(self):
         uploaded_file = UploadedFile(upload_area=self.upload_area, name="file2",
                                      content_type="application/octet-stream; dcp-type=data", data="file2_content")
@@ -56,7 +56,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         file_validatable = scheduler.check_file_can_be_validated()
         self.assertEqual(False, file_validatable)
 
-    @patch('upload.common.upload_area.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES-1)
+    @patch('upload.common.upload_area.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES - 1)
     def test_check_file_can_be_validated_returns_true_if_file_is_not_too_large(self):
         uploaded_file = UploadedFile(upload_area=self.upload_area, name="file2",
                                      content_type="application/octet-stream; dcp-type=data", data="file2_content")

--- a/tests/unit/lambdas/api_server/test_area.py
+++ b/tests/unit/lambdas/api_server/test_area.py
@@ -171,28 +171,37 @@ class TestAreaApi(UploadTestCaseUsingMockAWS):
         self.assertEqual("<class 'datetime.datetime'>", str(type(record.get("checksum_started_at"))))
         self.assertEqual("<class 'datetime.datetime'>", str(type(record.get("checksum_ended_at"))))
 
-    @patch('upload.common.uploaded_file.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES+1)
+    @patch('upload.common.uploaded_file.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES + 1)
     @patch('upload.lambdas.api_server.v1.area.IngestNotifier.connect')
     @patch('upload.lambdas.api_server.v1.area.IngestNotifier.format_and_send_notification')
-    def test_schedule_file_validation_raises_error_if_file_too_large(self, mock_format_and_send_notification, mock_connect):
+    def test_schedule_file_validation_raises_error_if_file_too_large(self, mock_format_and_send_notification,
+                                                                     mock_connect):
         area_id = self._create_area()
-        s3obj = self._mock_upload_file(area_id, 'foo.json')
-        response = self.client.put(f"/v1/area/{area_id}/foo.json/validate", headers=self.authentication_header, json={"validator_image": "humancellatlas/upload-validator-example"})
+        self._mock_upload_file(area_id, 'foo.json')
+        response = self.client.put(
+            f"/v1/area/{area_id}/foo.json/validate",
+            headers=self.authentication_header,
+            json={"validator_image": "humancellatlas/upload-validator-example"}
+        )
+        expected_decoded_response_data = '{\n  "status": 400,\n  "title": "File too large for validation"\n}\n'
+        self.assertEqual(expected_decoded_response_data, response.data.decode())
+
         self.assertEqual(400, response.status_code)
 
-
-
-    @patch('upload.common.upload_area.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES-1)
+    @patch('upload.common.upload_area.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES - 1)
     @patch('upload.lambdas.api_server.v1.area.ValidationScheduler.schedule_validation')
     @patch('upload.lambdas.api_server.v1.area.IngestNotifier.connect')
     @patch('upload.lambdas.api_server.v1.area.IngestNotifier.format_and_send_notification')
     def test_schedule_file_validation_doesnt_raise_error_for_correct_file_size(self, mock_format_and_send_notification,
-                                                                     mock_connect, mock_validate):
+                                                                               mock_connect, mock_validate):
         mock_validate.return_value = 4472093160
         area_id = self._create_area()
-        s3obj = self._mock_upload_file(area_id, 'foo.json')
-        response = self.client.put(f"/v1/area/{area_id}/foo.json/validate", headers=self.authentication_header,
-                            json={"validator_image": "humancellatlas/upload-validator-example"})
+        self._mock_upload_file(area_id, 'foo.json')
+        response = self.client.put(
+            f"/v1/area/{area_id}/foo.json/validate",
+            headers=self.authentication_header,
+            json={"validator_image": "humancellatlas/upload-validator-example"}
+        )
         self.assertEqual(200, response.status_code)
 
     @patch('upload.lambdas.api_server.v1.area.IngestNotifier.connect')

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -69,7 +69,8 @@ def schedule_file_validation(upload_area_id: str, filename: str, json_request_bo
     body = json.loads(json_request_body)
     environment = body['environment'] if 'environment' in body else {}
     validation_scheduler = ValidationScheduler(file)
-    validation_scheduler.check_file_can_be_validated()
+    if not validation_scheduler.check_file_can_be_validated():
+        raise UploadException(status=requests.codes.bad_request, title="File too large for validation")
     validation_id = validation_scheduler.schedule_validation(body['validator_image'], environment)
     return {'validation_id': validation_id}, requests.codes.ok
 

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -68,7 +68,9 @@ def schedule_file_validation(upload_area_id: str, filename: str, json_request_bo
     file = upload_area.uploaded_file(urllib.parse.unquote(filename))
     body = json.loads(json_request_body)
     environment = body['environment'] if 'environment' in body else {}
-    validation_id = ValidationScheduler(file).schedule_validation(body['validator_image'], environment)
+    validation_scheduler = ValidationScheduler(file)
+    validation_scheduler.check_file_can_be_validated()
+    validation_id = validation_scheduler.schedule_validation(body['validator_image'], environment)
     return {'validation_id': validation_id}, requests.codes.ok
 
 

--- a/upload/lambdas/api_server/validation_scheduler.py
+++ b/upload/lambdas/api_server/validation_scheduler.py
@@ -4,9 +4,7 @@ import re
 import urllib.parse
 import uuid
 import boto3
-import requests
 
-from upload.common.exceptions import UploadException
 from ...common.uploaded_file import UploadedFile
 from ...common.batch import JobDefinition
 from ...common.retry import retry_on_aws_too_many_requests

--- a/upload/lambdas/api_server/validation_scheduler.py
+++ b/upload/lambdas/api_server/validation_scheduler.py
@@ -4,7 +4,9 @@ import re
 import urllib.parse
 import uuid
 import boto3
+import requests
 
+from upload.common.exceptions import UploadException
 from ...common.uploaded_file import UploadedFile
 from ...common.batch import JobDefinition
 from ...common.retry import retry_on_aws_too_many_requests
@@ -22,6 +24,10 @@ class ValidationScheduler:
         self.file = uploaded_file
         self.file_key = self.file.upload_area.uuid + '/' + urllib.parse.quote(self.file.name)
         self.config = UploadConfig()
+
+    def check_file_can_be_validated(self):
+        if self.file.size >= 1000000000000:
+            raise UploadException(status=requests.codes.bad_request, title="File too large for validation")
 
     def schedule_validation(self, validator_docker_image: str, environment: dict) -> str:
         validation_id = str(uuid.uuid4())

--- a/upload/lambdas/api_server/validation_scheduler.py
+++ b/upload/lambdas/api_server/validation_scheduler.py
@@ -14,6 +14,8 @@ from ...common.validation_event import UploadedFileValidationEvent
 from ...common.upload_config import UploadConfig
 
 batch = boto3.client('batch')
+# 1tb volume limit for staging files from s3 during validation process
+MAX_FILE_SIZE_IN_BYTES = 1000000000000
 
 
 class ValidationScheduler:
@@ -26,8 +28,9 @@ class ValidationScheduler:
         self.config = UploadConfig()
 
     def check_file_can_be_validated(self):
-        if self.file.size >= 1000000000000:
-            raise UploadException(status=requests.codes.bad_request, title="File too large for validation")
+        if self.file.size >= MAX_FILE_SIZE_IN_BYTES:
+            return False
+        return True
 
     def schedule_validation(self, validator_docker_image: str, environment: dict) -> str:
         validation_id = str(uuid.uuid4())


### PR DESCRIPTION
-add hca to dev reqs
-add file size check to validation scheduler

Check file size before scheduling validation. If file is larger than 1TB should raise and exception and return a BadRequest response to the user.

Questions/Concerns
- is `test_error_not_thrown_if_file_is_appropriate_size` necessary? should I remove it?
