### PR TITLE
change all locations of terraform state buckets

### DIFF
--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = "=0.11.7"
 
   backend "s3" {
-    bucket  = "org-humancellatlas-dcp-infra"
-    key     = "terraform/upload-service/envs/dev/state.tfstate"
+    bucket  = "org-humancellatlas-upload-infra"
+    key     = "terraform/envs/dev/state.tfstate"
     encrypt = true
     region  = "us-east-1"
-    profile = "hca-id"
+    profile = "hca"
   }
 }
 

--- a/terraform/envs/integration/main.tf
+++ b/terraform/envs/integration/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = "=0.11.7"
 
   backend "s3" {
-    bucket  = "org-humancellatlas-dcp-infra"
-    key     = "terraform/upload-service/envs/integration/state.tfstate"
+    bucket  = "org-humancellatlas-upload-infra"
+    key     = "terraform/envs/integration/state.tfstate"
     encrypt = true
     region  = "us-east-1"
-    profile = "hca-id"
+    profile = "hca"
   }
 }
 

--- a/terraform/envs/predev/main.tf
+++ b/terraform/envs/predev/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = "=0.11.7"
 
   backend "s3" {
-    bucket  = "org-humancellatlas-dcp-infra"
-    key     = "terraform/upload-service/envs/predev/state.tfstate"
+    bucket  = "org-humancellatlas-upload-infra"
+    key     = "terraform/envs/predev/state.tfstate"
     encrypt = true
     region  = "us-east-1"
-    profile = "hca-id"
+    profile = "hca"
   }
 }
 

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = "=0.11.7"
 
   backend "s3" {
-    bucket  = "org-humancellatlas-dcp-infra"
-    key     = "terraform/upload-service/envs/prod/state.tfstate"
+    bucket  = "org-humancellatlas-upload-prod-infra"
+    key     = "terraform/envs/prod/state.tfstate"
     encrypt = true
     region  = "us-east-1"
-    profile = "hca-id"
+    profile = "hca-prod"
   }
 }
 

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = "=0.11.7"
 
   backend "s3" {
-    bucket  = "org-humancellatlas-dcp-infra"
-    key     = "terraform/upload-service/envs/staging/state.tfstate"
+    bucket  = "org-humancellatlas-upload-infra"
+    key     = "terraform/envs/staging/state.tfstate"
     encrypt = true
     region  = "us-east-1"
-    profile = "hca-id"
+    profile = "hca"
   }
 }
 

--- a/terraform/envs/test/main.tf
+++ b/terraform/envs/test/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = "=0.11.7"
 
   backend "s3" {
-    bucket  = "org-humancellatlas-dcp-infra"
-    key     = "terraform/upload-service/envs/test/state.tfstate"
+    bucket  = "org-humancellatlas-upload-infra"
+    key     = "terraform/envs/test/state.tfstate"
     encrypt = true
     region  = "us-east-1"
-    profile = "hca-id"
+    profile = "hca"
   }
 }
 


### PR DESCRIPTION
This is needed for gitlab to run terraform plan without reaching into hca-id buckets unnecessarily. This also allows us to remove upload specific policy from dcp-developer that was added in https://github.com/chanzuckerberg/dcp-infra/pull/43 to access these buckets.