### PR TITLE
Fix multipart threshold

### DIFF
--- a/upload/common/checksum.py
+++ b/upload/common/checksum.py
@@ -54,7 +54,7 @@ class UploadedFileChecksummer:
 
     def _transfer_config(self) -> TransferConfig:
         etag_stride = self._s3_chunk_size(self.uploaded_file.s3obj.content_length)
-        return TransferConfig(multipart_threshold=etag_stride,
+        return TransferConfig(multipart_threshold=(64 * MB) + 1,
                               multipart_chunksize=etag_stride)
 
     @staticmethod


### PR DESCRIPTION
Multipart uploads should start at 64MB+1, not 64MB.

reference: https://github.com/HumanCellAtlas/data-store/pull/1456