### PR TITLE
fix for hash in filename in scripts

### DIFF
--- a/scripts/retrieve_validation_statuses.py
+++ b/scripts/retrieve_validation_statuses.py
@@ -6,13 +6,15 @@ This script retrieves fastq validation job statuses and results for all files in
 import argparse
 import os
 import requests
+import urllib.parse
 
 
 def main(args):
     data_dir_path = "/data/{0}".format(args.dataset_name)
     for file in os.listdir(data_dir_path):
         if "fastq" in file:
-            upload_url = "https://upload.{0}.data.humancellatlas.org/v1/area/{1}/{2}/validate".format(args.environment, args.upload_area_id, file)
+            filename = urllib.parse.quote(file)
+            upload_url = "https://upload.{0}.data.humancellatlas.org/v1/area/{1}/{2}/validate".format(args.environment, args.upload_area_id, filename)
             headers = {'Api-Key': args.api_key}
             message = {"validator_image": "quay.io/humancellatlas/fastq_utils:master"}
             response = requests.get(upload_url, headers=headers, json=message)

--- a/scripts/schedule_fastq_validation.py
+++ b/scripts/schedule_fastq_validation.py
@@ -6,13 +6,15 @@ This script schedules fastq validation for all files in an upload area id
 import argparse
 import os
 import requests
+import urllib.parse
 
 
 def main(args):
     data_dir_path = "/data/{0}".format(args.dataset_name)
     for file in os.listdir(data_dir_path):
         if "fastq" in file:
-            upload_url = "https://upload.{0}.data.humancellatlas.org/v1/area/{1}/{2}/validate".format(args.environment, args.upload_area_id, file)
+            filename = urllib.parse.quote(file)
+            upload_url = "https://upload.{0}.data.humancellatlas.org/v1/area/{1}/{2}/validate".format(args.environment, args.upload_area_id, filename)
             headers = {'Api-Key': args.api_key}
             message = {"validator_image": "quay.io/humancellatlas/fastq_utils:master"}
             response = requests.put(upload_url, headers=headers, json=message)


### PR DESCRIPTION
Simple fix to https://app.zenhub.com/workspace/o/humancellatlas/upload-service/issues/138. No changes to docker image needed on further inspection since they call back to upload api with event_id (validation or checksum db unique id) instead of filename