### PR TITLE
terraform: create RDS security group

### DIFF
--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 1.16"
+  version = ">= 1.31"
   region = "us-east-1"
   profile = "hca"
 }
@@ -43,7 +43,6 @@ module "upload-service" {
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
-  vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -24,7 +24,6 @@ csum_cluster_ec2_key_pair = "my-ec2-keypair"
 csum_cluster_min_vcpus = 0
 
 // Database
-vpc_rds_security_group_id = "sg-xxxxxxxx"
 db_username = "xxxxxxxx"
 db_password = "xxxxxxxxxxxxx"
 db_instance_count = 1

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -48,9 +48,6 @@ variable "csum_cluster_min_vcpus" {
 
 // RDS
 
-variable "vpc_rds_security_group_id" {
-  type = "string"
-}
 variable "db_username" {
   type = "string"
 }

--- a/terraform/envs/integration/main.tf
+++ b/terraform/envs/integration/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 1.16"
+  version = ">= 1.31"
   region = "us-east-1"
   profile = "hca"
 }
@@ -43,7 +43,6 @@ module "upload-service" {
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
-  vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"

--- a/terraform/envs/predev/main.tf
+++ b/terraform/envs/predev/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 1.26"
+  version = ">= 1.31"
   region = "us-east-1"
   profile = "hca"
 }
@@ -43,7 +43,6 @@ module "upload-service" {
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
-  vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 1.16"
+  version = ">= 1.31"
   region = "us-east-1"
   profile = "hca-prod"
 }
@@ -43,7 +43,6 @@ module "upload-service" {
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
-  vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 1.16"
+  version = ">= 1.31"
   region = "us-east-1"
   profile = "hca"
 }
@@ -43,7 +43,6 @@ module "upload-service" {
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database
-  vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"

--- a/terraform/envs/test/main.tf
+++ b/terraform/envs/test/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 1.16"
+  version = ">= 1.31"
   region = "us-east-1"
   profile = "hca"
 }
@@ -19,7 +19,6 @@ provider "aws" {
 module "upload-service-database" {
   source = "../../modules/database"
   deployment_stage = "${var.deployment_stage}"
-  vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"

--- a/terraform/envs/test/terraform.tfvars.example
+++ b/terraform/envs/test/terraform.tfvars.example
@@ -1,5 +1,4 @@
 // Database
-vpc_rds_security_group_id = "sg-xxxxxxxx"
 db_username = "xxxxxxxx"
 db_password = "xxxxxxxxxxxxxx"
 vpc_id = "vpc-xxxxxxxx"

--- a/terraform/envs/test/variables.tf
+++ b/terraform/envs/test/variables.tf
@@ -3,9 +3,6 @@ variable "deployment_stage" {
   default = "test"
 }
 
-variable "vpc_rds_security_group_id" {
-  type = "string"
-}
 variable "db_username" {
   type = "string"
 }

--- a/terraform/modules/database/database.tf
+++ b/terraform/modules/database/database.tf
@@ -26,7 +26,7 @@ resource "aws_rds_cluster" "upload" {
   preferred_maintenance_window = "sat:09:08-sat:09:38"
   storage_encrypted       = "true"
   skip_final_snapshot     = "true"
-  vpc_security_group_ids  = ["${var.vpc_rds_security_group_id}"]
+  vpc_security_group_ids  = ["${aws_security_group.rds-postgres.id}"]
   db_subnet_group_name    = "default"
   db_cluster_parameter_group_name = "default.aurora-postgresql9.6"
 }

--- a/terraform/modules/database/pgbouncer.tf
+++ b/terraform/modules/database/pgbouncer.tf
@@ -64,7 +64,7 @@ resource "aws_ecs_service" "pgbouncer" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    security_groups = ["${var.vpc_rds_security_group_id}"]
+    security_groups = ["${aws_security_group.rds-postgres.id}"]
     subnets         = ["${var.pgbouncer_subnet_id}"]
     assign_public_ip = true
   }

--- a/terraform/modules/database/security_group.tf
+++ b/terraform/modules/database/security_group.tf
@@ -1,0 +1,20 @@
+resource "aws_security_group" "rds-postgres" {
+  name        = "dcp-upload-${var.deployment_stage}-rds-postgres-sg"
+  description = "DCP Upload Service Postgres"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "all"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -14,10 +14,6 @@ variable "deployment_stage" {
   type = "string"
 }
 
-variable "vpc_rds_security_group_id" {
-  type = "string"
-}
-
 variable "db_username" {
   type = "string"
 }

--- a/terraform/modules/upload-service/main.tf
+++ b/terraform/modules/upload-service/main.tf
@@ -6,7 +6,6 @@ locals {
 module "upload-service-database" {
   source = "../../modules/database"
   deployment_stage = "${var.deployment_stage}"
-  vpc_rds_security_group_id = "${var.vpc_rds_security_group_id}"
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -52,10 +52,6 @@ variable "csum_cluster_min_vcpus" {
 
 # Database
 
-variable "vpc_rds_security_group_id" {
-  type = "string"
-}
-
 variable "db_username" {
   type = "string"
 }


### PR DESCRIPTION
removes all that need for passing around `vpc_rds_security_group_id`

Also:

Upgrade aws provider dependency to 1.31.  We cannot run with less
than 1.26 anymore (supports sqs -> lambda trigger).