### PR TITLE
Make upload service installable

### DIFF
--- a/daemons/upload-checksum-daemon/Makefile
+++ b/daemons/upload-checksum-daemon/Makefile
@@ -1,17 +1,16 @@
 include ../../common.mk
+.PHONY: install build stage deploy
 
-ZIP_FILE := checksum_daemon.zip
-TARGET := target/$(ZIP_FILE)
+ZIP_FILE=checksum_daemon.zip
+BUCKET=$(BUCKET_NAME_PREFIX)checksum-lambda-deployment
+STAGED_FILE_KEY=$(DEPLOYMENT_STAGE)/$(ZIP_FILE)
 
 default: build
 
-.PHONY: install
 install:
 	virtualenv -p python3 venv
 	. venv/bin/activate && pip install -r requirements.txt --upgrade
 
-
-.PHONY: build
 build:
 	rm -rf target
 	mkdir target
@@ -31,7 +30,8 @@ build:
 	cp -R vendor/* target/
 	cd target && zip -r ../$(ZIP_FILE) *
 
-.PHONY: deploy
-deploy: build
-	aws s3 cp $(ZIP_FILE) s3://org-humancellatlas-upload-checksum-lambda-deployment/$(DEPLOYMENT_STAGE)/$(ZIP_FILE)
-	aws lambda update-function-code --function-name dcp-upload-csum-$(DEPLOYMENT_STAGE) --s3-bucket org-humancellatlas-upload-checksum-lambda-deployment --s3-key $(DEPLOYMENT_STAGE)/$(ZIP_FILE)
+stage: build
+	aws s3 cp $(ZIP_FILE) s3://$(BUCKET)/$(STAGED_FILE_KEY)
+
+deploy: stage
+	aws lambda update-function-code --function-name dcp-upload-csum-$(DEPLOYMENT_STAGE) --s3-bucket $(BUCKET) --s3-key $(STAGED_FILE_KEY)

--- a/database/env.py
+++ b/database/env.py
@@ -6,7 +6,7 @@ import os
 import sys
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
-from upload.common.upload_config import UploadConfig
+from upload.common.upload_config import UploadDbConfig
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -71,8 +71,7 @@ def run_migrations_online():
     if os.environ["DEPLOYMENT_STAGE"] != db_name:
         raise Exception("Deployment stage os environ var and target db arg are different")
 
-    upload_config = UploadConfig()
-    alembic_config["sqlalchemy.url"] = upload_config.database_uri
+    alembic_config["sqlalchemy.url"] = UploadDbConfig().database_uri
 
     engine = engine_from_config(
         alembic_config,

--- a/terraform/envs/dev/Makefile
+++ b/terraform/envs/dev/Makefile
@@ -1,3 +1,7 @@
+DEPLOYMENT_STAGE=dev
+TF_STATE_BUCKET=org-humancellatlas-upload-infra
+S3_TFVARS_FILE=s3://$(TF_STATE_BUCKET)/terraform/envs/$(DEPLOYMENT_STAGE)/terraform.tfvars
+
 default: plan
 
 init:
@@ -12,10 +16,10 @@ apply:
 	terraform apply --backup=-
 
 retrieve-vars:
-	aws s3 cp s3://org-humancellatlas-upload-infra/terraform/envs/dev/terraform.tfvars terraform.tfvars
+	aws s3 cp $(S3_TFVARS_FILE) terraform.tfvars
 
 upload-vars:
-	aws s3 cp terraform.tfvars s3://org-humancellatlas-upload-infra/terraform/envs/dev/terraform.tfvars
+	aws s3 cp terraform.tfvars $(S3_TFVARS_FILE)
 
 import:
 	# These resources are shared between deployments in the same account

--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -19,9 +19,7 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-
-  vpc_id = "${var.vpc_id}"
-  vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+  vpc_cidr_block = "${var.vpc_cidr_block}"
 
   // S3
   bucket_name_prefix = "${var.bucket_name_prefix}"

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -1,8 +1,7 @@
 deployment_stage = "XXX"
 
-// The VPC in which you want your Batch infrastructure deployed.
-vpc_id = "vpc-xxxxxxxx"
-vpc_default_security_group_id = "sg-xxxxxxxx"
+// VPC
+vpc_cidr_block = "xxx.xxx.xxx.xxx/xx"
 
 // S3
 bucket_name_prefix = "org-humancellatlas-upload-"

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -1,10 +1,10 @@
 variable "deployment_stage" {
   type = "string"
 }
-variable "vpc_id" {
-  type = "string"
-}
-variable "vpc_default_security_group_id" {
+
+// VPC
+
+variable "vpc_cidr_block" {
   type = "string"
 }
 
@@ -24,6 +24,7 @@ variable "ingest_api_key" {
 }
 
 // Checksum Lambda
+
 variable "csum_docker_image" {
   type = "string"
 }

--- a/terraform/envs/integration/main.tf
+++ b/terraform/envs/integration/main.tf
@@ -19,9 +19,7 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-
-  vpc_id = "${var.vpc_id}"
-  vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+  vpc_cidr_block = "${var.vpc_cidr_block}"
 
   // S3
   bucket_name_prefix = "${var.bucket_name_prefix}"

--- a/terraform/envs/predev/main.tf
+++ b/terraform/envs/predev/main.tf
@@ -19,9 +19,7 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-
-  vpc_id = "${var.vpc_id}"
-  vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+  vpc_cidr_block = "${var.vpc_cidr_block}"
 
   // S3
   bucket_name_prefix = "${var.bucket_name_prefix}"

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -19,9 +19,7 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-
-  vpc_id = "${var.vpc_id}"
-  vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+  vpc_cidr_block = "${var.vpc_cidr_block}"
 
   // S3
   bucket_name_prefix = "${var.bucket_name_prefix}"

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -19,9 +19,7 @@ provider "aws" {
 module "upload-service" {
   source = "../../modules/upload-service"
   deployment_stage = "${var.deployment_stage}"
-
-  vpc_id = "${var.vpc_id}"
-  vpc_default_security_group_id = "${var.vpc_default_security_group_id}"
+  vpc_cidr_block = "${var.vpc_cidr_block}"
 
   // S3
   bucket_name_prefix = "${var.bucket_name_prefix}"

--- a/terraform/envs/test/main.tf
+++ b/terraform/envs/test/main.tf
@@ -35,8 +35,6 @@ resource "aws_secretsmanager_secret_version" "secrets" {
   secret_id = "${aws_secretsmanager_secret.secrets.id}"
   secret_string = <<SECRETS_JSON
 {
-  "database_uri": "${module.upload-service-database.database_uri}",
-  "pgbouncer_uri": "${module.upload-service-database.pgbouncer_uri}",
   "bucket_name": "bogo-bucket"
 }
 SECRETS_JSON

--- a/terraform/envs/test/terraform.tfvars.example
+++ b/terraform/envs/test/terraform.tfvars.example
@@ -1,5 +1,6 @@
+// VPC
+vpc_cidr_block = "xxx.xxx.xxx.xxx/xx"
 // Database
 db_username = "xxxxxxxx"
 db_password = "xxxxxxxxxxxxxx"
-vpc_id = "vpc-xxxxxxxx"
 db_instance_count = 1

--- a/terraform/envs/test/variables.tf
+++ b/terraform/envs/test/variables.tf
@@ -3,6 +3,10 @@ variable "deployment_stage" {
   default = "test"
 }
 
+variable "vpc_cidr_block" {
+  type = "string"
+}
+
 variable "db_username" {
   type = "string"
 }
@@ -11,17 +15,4 @@ variable "db_password" {
 }
 variable "db_instance_count" {
   type = "string"
-}
-
-variable "vpc_id" {
-  type = "string"
-}
-
-data "aws_subnet_ids" "vpc" {
-  vpc_id = "${var.vpc_id}"
-}
-
-data "aws_subnet" "vpc" {
-  count = "${length(data.aws_subnet_ids.vpc.ids)}"
-  id = "${data.aws_subnet_ids.vpc.ids[count.index]}"
 }

--- a/terraform/modules/database/database.tf
+++ b/terraform/modules/database/database.tf
@@ -27,6 +27,6 @@ resource "aws_rds_cluster" "upload" {
   storage_encrypted       = "true"
   skip_final_snapshot     = "true"
   vpc_security_group_ids  = ["${aws_security_group.rds-postgres.id}"]
-  db_subnet_group_name    = "default"
+  db_subnet_group_name    = "${aws_db_subnet_group.db_subnet_group.name}"
   db_cluster_parameter_group_name = "default.aurora-postgresql9.6"
 }

--- a/terraform/modules/database/outputs.tf
+++ b/terraform/modules/database/outputs.tf
@@ -1,7 +1,0 @@
-output "database_uri" {
-  value = "postgresql://${aws_rds_cluster.upload.master_username}:${aws_rds_cluster.upload.master_password}@${aws_rds_cluster.upload.endpoint}/${aws_rds_cluster.upload.database_name}"
-}
-
-output "pgbouncer_uri" {
-  value = "postgresql://${aws_rds_cluster.upload.master_username}:${aws_rds_cluster.upload.master_password}@${aws_lb.main.dns_name}/${aws_rds_cluster.upload.database_name}"
-}

--- a/terraform/modules/database/pgbouncer.tf
+++ b/terraform/modules/database/pgbouncer.tf
@@ -76,7 +76,7 @@ resource "aws_ecs_service" "pgbouncer" {
   }
 
   depends_on = [
-    "aws_lb_listener.front_end", "aws_ecs_task_definition.pgbouncer"
+    "aws_lb_listener.front_end", "aws_rds_cluster_instance.cluster_instances"
   ]
 }
 

--- a/terraform/modules/database/secrets.tf
+++ b/terraform/modules/database/secrets.tf
@@ -1,0 +1,16 @@
+
+resource "aws_secretsmanager_secret" "database-secrets" {
+  name = "dcp/upload/${var.deployment_stage}/database"
+}
+
+resource "aws_secretsmanager_secret_version" "database-secrets" {
+  secret_id = "${aws_secretsmanager_secret.database-secrets.id}"
+  secret_string = <<SECRETS_JSON
+{
+  "database_uri": "postgresql://${aws_rds_cluster.upload.master_username}:${aws_rds_cluster.upload.master_password}@${aws_rds_cluster.upload.endpoint}/${aws_rds_cluster.upload.database_name}",
+  "pgbouncer_uri": "postgresql://${aws_rds_cluster.upload.master_username}:${aws_rds_cluster.upload.master_password}@${aws_lb.main.dns_name}/${aws_rds_cluster.upload.database_name}"
+}
+SECRETS_JSON
+
+  depends_on = [ "aws_ecs_service.pgbouncer" ]
+}

--- a/terraform/modules/database/subnet.tf
+++ b/terraform/modules/database/subnet.tf
@@ -1,0 +1,8 @@
+resource "aws_db_subnet_group" "db_subnet_group" {
+  name       = "upload_db_subnet_group"
+  subnet_ids = ["${var.lb_subnet_ids}"]
+
+  tags {
+    Name = "DCP Upload DB Subnet Group"
+  }
+}

--- a/terraform/modules/upload-service/api_lambda.tf
+++ b/terraform/modules/upload-service/api_lambda.tf
@@ -94,7 +94,7 @@ resource "aws_iam_role_policy" "upload_api_lambda" {
         "secretsmanager:GetSecretValue"
       ],
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:${local.account_id}:secret:dcp/upload/${var.deployment_stage}/*"
+        "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:dcp/upload/${var.deployment_stage}/*"
       ]
     }
   ]

--- a/terraform/modules/upload-service/checksumming_batch.tf
+++ b/terraform/modules/upload-service/checksumming_batch.tf
@@ -65,6 +65,16 @@ resource "aws_iam_policy" "csum_job_policy" {
             "Resource": [
                 "arn:aws:s3:::${aws_s3_bucket.upload_areas_bucket.bucket}/*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": [
+                "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:dcp/upload/${var.deployment_stage}/*"
+            ]
         }
     ]
 }

--- a/terraform/modules/upload-service/checksumming_batch.tf
+++ b/terraform/modules/upload-service/checksumming_batch.tf
@@ -24,10 +24,10 @@ resource "aws_batch_compute_environment" "csum_compute_env" {
       "m4"
     ]
     subnets = [
-      "${data.aws_subnet.vpc.*.id}"
+      "${data.aws_subnet_ids.upload_vpc.ids}"
     ]
     security_group_ids = [
-      "${var.vpc_default_security_group_id}"
+      "${module.upload-vpc.vpc_default_security_group_id}"
     ]
     ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
     instance_role = "${aws_iam_instance_profile.ecsInstanceRole.arn}"

--- a/terraform/modules/upload-service/checksumming_lambda.tf
+++ b/terraform/modules/upload-service/checksumming_lambda.tf
@@ -79,7 +79,7 @@ resource "aws_iam_role_policy" "upload_csum_lambda" {
         "secretsmanager:GetSecretValue"
       ],
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:${local.account_id}:secret:dcp/upload/${var.deployment_stage}/*"
+        "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:dcp/upload/${var.deployment_stage}/*"
       ]
     },
     {

--- a/terraform/modules/upload-service/main.tf
+++ b/terraform/modules/upload-service/main.tf
@@ -4,13 +4,20 @@ locals {
   aws_region = "${data.aws_region.current.name}"
 }
 
+module "upload-vpc" {
+  source = "../../modules/vpc"
+  component_name = "upload"
+  deployment_stage = "${var.deployment_stage}"
+  vpc_cidr_block = "${var.vpc_cidr_block}"
+}
+
 module "upload-service-database" {
   source = "../../modules/database"
   deployment_stage = "${var.deployment_stage}"
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
-  pgbouncer_subnet_id = "${element(data.aws_subnet_ids.vpc.ids, 0)}"
-  lb_subnet_ids = "${data.aws_subnet_ids.vpc.ids}"
-  vpc_id = "${var.vpc_id}"
+  pgbouncer_subnet_id = "${element(data.aws_subnet_ids.upload_vpc.ids, 0)}"
+  lb_subnet_ids = "${data.aws_subnet_ids.upload_vpc.ids}"
+  vpc_id = "${module.upload-vpc.vpc_id}"
 }

--- a/terraform/modules/upload-service/main.tf
+++ b/terraform/modules/upload-service/main.tf
@@ -1,6 +1,7 @@
 locals {
   bucket_name = "${var.bucket_name_prefix}${var.deployment_stage}"
   account_id = "${data.aws_caller_identity.current.account_id}"
+  aws_region = "${data.aws_region.current.name}"
 }
 
 module "upload-service-database" {

--- a/terraform/modules/upload-service/secrets.tf
+++ b/terraform/modules/upload-service/secrets.tf
@@ -7,8 +7,6 @@ resource "aws_secretsmanager_secret_version" "secrets" {
   secret_string = <<SECRETS_JSON
 {
   "bucket_name": "${aws_s3_bucket.upload_areas_bucket.bucket}",
-  "database_uri": "${module.upload-service-database.database_uri}",
-  "pgbouncer_uri": "${module.upload-service-database.pgbouncer_uri}",
   "validation_job_q_arn": "${aws_batch_job_queue.validation_job_q.arn}",
   "validation_job_role_arn": "${aws_iam_role.validation_job_role.arn}",
   "csum_job_q_arn": "${aws_batch_job_queue.csum_job_q.arn}",

--- a/terraform/modules/upload-service/validation.tf
+++ b/terraform/modules/upload-service/validation.tf
@@ -25,10 +25,10 @@ resource "aws_batch_compute_environment" "validation_compute_env" {
     ]
     image_id = "${var.validation_cluster_ami_id}"
     subnets = [
-      "${data.aws_subnet.vpc.*.id}"
+      "${data.aws_subnet_ids.upload_vpc.ids}"
     ]
     security_group_ids = [
-      "${var.vpc_default_security_group_id}"
+      "${module.upload-vpc.vpc_default_security_group_id}"
     ]
     ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
     instance_role = "${aws_iam_instance_profile.ecsInstanceRole.arn}"

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -75,6 +75,8 @@ variable "ingest_amqp_server" {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 data "aws_subnet_ids" "vpc" {
   vpc_id = "${var.vpc_id}"
 }

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -1,12 +1,10 @@
-variable "vpc_id" {
-  type = "string"
-}
-
-variable "vpc_default_security_group_id" {
-  type = "string"
-}
-
 variable "deployment_stage" {
+  type = "string"
+}
+
+// VPC
+
+variable "vpc_cidr_block" {
   type = "string"
 }
 
@@ -77,11 +75,6 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
-data "aws_subnet_ids" "vpc" {
-  vpc_id = "${var.vpc_id}"
-}
-
-data "aws_subnet" "vpc" {
-  count = "${length(data.aws_subnet_ids.vpc.ids)}"
-  id = "${data.aws_subnet_ids.vpc.ids[count.index]}"
+data "aws_subnet_ids" "upload_vpc" {
+  vpc_id = "${module.upload-vpc.vpc_id}"
 }

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,25 @@
+variable "component_name" {
+  type = "string"
+}
+
+variable "deployment_stage" {
+  type = "string"
+}
+
+variable "vpc_cidr_block" {
+  type = "string"
+}
+
+variable "subnet_bits" {
+  type = "string"
+  default = "4"
+}
+
+output "vpc_id" {
+  value = "${aws_vpc.vpc.id}"
+}
+
+output "vpc_default_security_group_id" {
+  value = "${aws_vpc.vpc.default_security_group_id}"
+}
+

--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -1,0 +1,135 @@
+//
+// A complete VPC implementation, including:
+//
+//  VPC
+//  DHCP option set
+//  Internet gateway
+//  Route table (main)
+//  One subnet in each availability zone
+//  Default security group
+
+data "aws_region" "current" {}
+data "aws_availability_zones" "available" {}
+
+locals {
+   // available.count == 1 so use length(names)
+  az_count = "${length(data.aws_availability_zones.available.names)}"
+  az_names = "${data.aws_availability_zones.available.names}"
+  aws_region = "${data.aws_region.current.name}"
+}
+
+// A dummy resource at the head of the graph that causes everything else to get instantiated
+// Can be used with terraform --target, e.g. --target=module.upload-service.module.upload-vpc.null_resource.vpc
+resource "null_resource" "vpc" {
+  depends_on = [
+    "aws_vpc_dhcp_options_association.a",
+    "aws_internet_gateway.igw",
+    "aws_main_route_table_association.a",
+    "aws_route_table_association.a",
+    "aws_default_security_group.sg"
+  ]
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block = "${var.vpc_cidr_block}"
+  enable_dns_support = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.component_name}-${var.deployment_stage}"
+    component = "${var.component_name}"
+    deployment_stage = "${var.deployment_stage}"
+  }
+}
+
+resource "aws_vpc_dhcp_options" "opts" {
+  domain_name          = "ec2.internal"
+  domain_name_servers  = ["AmazonProvidedDNS"]
+
+  tags = {
+    Name = "${var.component_name}-${var.deployment_stage}"
+    component = "${var.component_name}"
+    deployment_stage = "${var.deployment_stage}"
+  }
+}
+
+resource "aws_vpc_dhcp_options_association" "a" {
+  vpc_id          = "${aws_vpc.vpc.id}"
+  dhcp_options_id = "${aws_vpc_dhcp_options.opts.id}"
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  tags = {
+    Name = "${var.component_name}-${var.deployment_stage}"
+    component = "${var.component_name}"
+    deployment_stage = "${var.deployment_stage}"
+  }
+}
+
+resource "aws_route_table" "rt" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.igw.id}"
+  }
+
+  tags = {
+    Name = "${var.component_name}-${var.deployment_stage}"
+    component = "${var.component_name}"
+    deployment_stage = "${var.deployment_stage}"
+  }
+}
+
+resource "aws_main_route_table_association" "a" {
+  vpc_id         = "${aws_vpc.vpc.id}"
+  route_table_id = "${aws_route_table.rt.id}"
+}
+
+resource "aws_subnet" "sn" {
+  count = "${local.az_count}"
+
+  availability_zone = "${local.az_names[count.index]}"
+  cidr_block        = "${cidrsubnet(var.vpc_cidr_block, "${var.subnet_bits}", count.index)}"
+  vpc_id            = "${aws_vpc.vpc.id}"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.component_name}-${var.deployment_stage}-${local.az_names[count.index]}"
+    component = "${var.component_name}"
+    deployment_stage = "${var.deployment_stage}"
+  }
+}
+
+resource "aws_route_table_association" "a" {
+  count = "${aws_subnet.sn.count}"
+
+  subnet_id      = "${aws_subnet.sn.*.id[count.index]}"
+  route_table_id = "${aws_route_table.rt.id}"
+}
+
+resource "aws_default_security_group" "sg" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.component_name}-${var.deployment_stage}-default"
+    component = "${var.component_name}"
+    deployment_stage = "${var.deployment_stage}"
+  }
+}

--- a/upload/common/database.py
+++ b/upload/common/database.py
@@ -6,9 +6,9 @@ from sqlalchemy import create_engine, MetaData
 from sqlalchemy.exc import OperationalError, IntegrityError, DatabaseError
 
 from .exceptions import UploadException
-from .upload_config import UploadConfig
+from .upload_config import UploadDbConfig
 
-config = UploadConfig()
+config = UploadDbConfig()
 engine = create_engine(config.pgbouncer_uri, pool_size=1)
 meta = MetaData(engine, reflect=True)
 record_type_table_map = {

--- a/upload/common/database_orm.py
+++ b/upload/common/database_orm.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine, Column, Integer, String, DateTime, Foreign
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 
-from upload.common.upload_config import UploadConfig
+from upload.common.upload_config import UploadDbConfig
 
 
 Base = declarative_base()
@@ -65,7 +65,7 @@ DbUploadArea.files = relationship('DbFile', order_by=DbFile.id, back_populates='
 DbFile.checksums = relationship('DbChecksum', order_by=DbChecksum.created_at, back_populates='file')
 DbFile.validations = relationship('DbValidation', order_by=DbValidation.created_at, back_populates='file')
 
-engine = create_engine(UploadConfig().database_uri)
+engine = create_engine(UploadDbConfig().database_uri)
 Base.metadata.bind = engine
 db_session_maker = sessionmaker()
 db_session_maker.bind = engine

--- a/upload/common/upload_config.py
+++ b/upload/common/upload_config.py
@@ -7,6 +7,11 @@ class UploadConfig(Config):
         super().__init__('upload', **kwargs)
 
 
+class UploadDbConfig(Config):
+    def __init__(self, *args, **kwargs):
+        super().__init__(component_name='upload', secret_name='database', **kwargs)
+
+
 class UploadVersion(Config):
     def __init__(self, *args, **kwargs):
         super().__init__(component_name='upload', secret_name='upload_service_version', **kwargs)


### PR DESCRIPTION
You can now install new deployments of the upload service, without excessive messing about.
This document describes the process:
https://github.com/HumanCellAtlas/upload-service/wiki/Setting-up-a-new-Deployment-of-the-Upload-Service