### PR TITLE
endpoint to retrieve checksum job status on file

### DIFF
--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -313,6 +313,44 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /v1/area/{upload_area_id}/{filename}/checksum:
+
+    get:
+      summary: Get status and results of latest checksum job for a file
+      operationId: upload.lambdas.api_server.v1.area.retrieve_checksum_status_and_values
+      description: |
+        Get status and results of latest checksum job for a file.
+      tags:
+        - All
+      parameters:
+        - name: upload_area_id
+          in: path
+          description: A RFC4122-compliant ID for the upload area.
+          required: true
+          type: string
+        - name: filename
+          in: path
+          description: Name of file.  Must exist in the upload area.
+          required: true
+          type: string
+      responses:
+        200:
+          description: Checksum status
+          schema:
+            type: object
+            properties:
+              validation_status:
+                type: string
+                description: A status for the checksum job.
+        401:
+          description: Unrecognized Api-Key.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
   /v1/area/{upload_area_id}/{filename}/validate:
 
     put:
@@ -389,15 +427,8 @@ paths:
       description: |
         Get status and results of latest validation job for a file.
       tags:
-        - For Ingestion Service Use Only
-      security:
-        - api_key: []
+        - All
       parameters:
-        - name: Api-Key
-          in: header
-          description: An authentication token provided by the service provider.
-          required: true
-          type: string
         - name: upload_area_id
           in: path
           description: A RFC4122-compliant ID for the upload area.

--- a/upload/common/uploaded_file.py
+++ b/upload/common/uploaded_file.py
@@ -134,3 +134,14 @@ class UploadedFile:
             status = rows[0][0]
             results = rows[0][1]
         return status, results
+
+    def retrieve_latest_file_checksum_status_and_values(self):
+        status = "UNSCHEDULED"
+        checksums = None
+        query_results = run_query_with_params("SELECT status, checksums FROM checksum \
+            WHERE file_id = %s order by created_at desc limit 1;", (self.s3obj.key,))
+        rows = query_results.fetchall()
+        if len(rows) > 0:
+            status = rows[0][0]
+            checksums = rows[0][1]
+        return status, checksums

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -76,12 +76,19 @@ def schedule_file_validation(upload_area_id: str, filename: str, json_request_bo
 
 
 @return_exceptions_as_http_errors
-@require_authenticated
 def retrieve_validation_status_and_results(upload_area_id: str, filename: str):
     upload_area = _load_upload_area(upload_area_id)
     file = upload_area.uploaded_file(urllib.parse.unquote(filename))
     status, results = file.retrieve_latest_file_validation_status_and_results()
     return {'validation_status': status, 'validation_results': results}, requests.codes.ok
+
+
+@return_exceptions_as_http_errors
+def retrieve_checksum_status_and_values(upload_area_id: str, filename: str):
+    upload_area = _load_upload_area(upload_area_id)
+    file = upload_area.uploaded_file(urllib.parse.unquote(filename))
+    status, checksums = file.retrieve_latest_file_checksum_status_and_values()
+    return {'checksum_status': status, 'checksums': checksums}, requests.codes.ok
 
 
 @return_exceptions_as_http_errors


### PR DESCRIPTION
Similar to endpoint to retrieve validation job status on a file. This will enable https://app.zenhub.com/workspace/o/humancellatlas/upload-service/issues/169