### PR TITLE
add endpoints to get status (checksum and validation) of all files in an upload area

### DIFF
--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -238,6 +238,64 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /v1/area/{upload_area_id}/validation_statuses:
+
+    get:
+      summary: Get count of validation statuses for all files in upload_area
+      operationId: upload.lambdas.api_server.v1.area.retrieve_validation_status_count
+      description:  |
+        Provide a JSON object with number of files in a particular upload area
+        that are validating, scheduled for validation and validated
+      tags:
+        - All
+      responses:
+        200:
+          description: Here is the file status count
+          type: object
+            properties:
+              VALIDATING:
+                type: integer
+              VALIDATED:
+                type: integer
+              SCHEDULED:
+                type: integer
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /v1/area/{upload_area_id}/checksum_statuses:
+
+    get:
+      summary: Get count of checksum statuses for all files in upload_area
+      operationId: upload.lambdas.api_server.v1.area.retrieve_validation_status_count
+      description:  |
+        Provide a JSON object with number of files in a particular upload area
+        that are validating, scheduled for validation and validated
+      tags:
+        - All
+      responses:
+        200:
+          description: Here is the file status count
+          type: object
+            properties:
+              CHECKSUMMING:
+                type: integer
+              CHECKSUMMED:
+                type: integer
+              SCHEDULED:
+                type: integer
+              UNSCHEDULED:
+                type: integer
+              TOTAL_NUM_FILES:
+                type: integer
+
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+
   /v1/area/{upload_area_id}/{filename}:
 
     put:

--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -238,7 +238,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /v1/area/{upload_area_id}/validation_statuses:
+  /v1/area/{upload_area_id}/validations:
 
     get:
       summary: Get count of validation statuses for all files in upload_area
@@ -248,10 +248,17 @@ paths:
         that are validating, scheduled for validation and validated
       tags:
         - All
+      parameters:
+        - name: upload_area_id
+          in: path
+          description: A RFC4122-compliant ID for the upload area.
+          required: true
+          type: string
       responses:
         200:
           description: Here is the file status count
-          type: object
+          schema:
+            type: object
             properties:
               VALIDATING:
                 type: integer
@@ -264,20 +271,27 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /v1/area/{upload_area_id}/checksum_statuses:
+  /v1/area/{upload_area_id}/checksums:
 
     get:
       summary: Get count of checksum statuses for all files in upload_area
-      operationId: upload.lambdas.api_server.v1.area.retrieve_validation_status_count
+      operationId: upload.lambdas.api_server.v1.area.retrieve_checksum_status_count
       description:  |
-        Provide a JSON object with number of files in a particular upload area
-        that are validating, scheduled for validation and validated
+        Provide a JSON object with number of files that are in a particular upload area,
+        scheduled for checksumming, checksumming, checksummed, and unescheduled.
       tags:
         - All
+      parameters:
+        - name: upload_area_id
+          in: path
+          description: A RFC4122-compliant ID for the upload area.
+          required: true
+          type: string
       responses:
         200:
           description: Here is the file status count
-          type: object
+          schema:
+            type: object
             properties:
               CHECKSUMMING:
                 type: integer

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -181,7 +181,7 @@ class UploadArea:
         update_pg_record("upload_area", prop_vals_dict)
 
     def retrieve_file_checksum_statuses_for_upload_area(self):
-        checksum_status_dict = {
+        checksum_status = {
             'TOTAL_NUM_FILES': self.retrieve_file_count_for_upload_area(),
             'CHECKSUMMING': 0,
             'CHECKSUMMED': 0,
@@ -193,10 +193,10 @@ class UploadArea:
         checksumming_file_count = 0
         if len(results) > 0:
             for status in results:
-                checksum_status_dict[status[0]] = status[1]
+                checksum_status[status[0]] = status[1]
                 checksumming_file_count += status[1]
-        checksum_status_dict['CHECKSUMMING_UNSCHEDULED'] = checksum_status_dict['TOTAL_NUM_FILES'] - checksumming_file_count
-        return checksum_status_dict
+        checksum_status['CHECKSUMMING_UNSCHEDULED'] = checksum_status['TOTAL_NUM_FILES'] - checksumming_file_count
+        return checksum_status
 
     def retrieve_file_validation_statuses_for_upload_area(self):
         query_result = run_query_with_params("SELECT status, COUNT(DISTINCT validation.file_id) FROM validation "
@@ -216,4 +216,3 @@ class UploadArea:
         query_result = run_query_with_params("SELECT COUNT(DISTINCT name) FROM file WHERE upload_area_id=%s", self.uuid)
         results = query_result.fetchall()
         return results[0][0]
-

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -14,7 +14,7 @@ from .upload_config import UploadConfig
 from .logging import get_logger
 
 if not os.environ.get("CONTAINER"):
-    from .database import get_pg_record, create_pg_record, update_pg_record
+    from .database import get_pg_record, create_pg_record, update_pg_record, run_query_with_params
 
 logger = get_logger(__name__)
 
@@ -179,3 +179,41 @@ class UploadArea:
     def _update_record(self):
         prop_vals_dict = self._format_prop_vals_dict()
         update_pg_record("upload_area", prop_vals_dict)
+
+    def retrieve_file_checksum_statuses_for_upload_area(self):
+        checksum_status_dict = {
+            'TOTAL_NUM_FILES': self.retrieve_file_count_for_upload_area(),
+            'CHECKSUMMING': 0,
+            'CHECKSUMMED': 0,
+            'CHECKSUMMING_UNSCHEDULED': 0
+        }
+        query_result = run_query_with_params("SELECT status, COUNT(DISTINCT checksum.file_id) FROM checksum "
+                                             "WHERE file_id LIKE %s GROUP BY  status;", (f"{self.uuid}/%",))
+        results = query_result.fetchall()
+        checksumming_file_count = 0
+        if len(results) > 0:
+            for status in results:
+                checksum_status_dict[status[0]] = status[1]
+                checksumming_file_count += status[1]
+        checksum_status_dict['CHECKSUMMING_UNSCHEDULED'] = checksum_status_dict['TOTAL_NUM_FILES'] - checksumming_file_count
+        return checksum_status_dict
+
+    def retrieve_file_validation_statuses_for_upload_area(self):
+        query_result = run_query_with_params("SELECT status, COUNT(DISTINCT validation.file_id) FROM validation "
+                                             "WHERE file_id LIKE %s GROUP BY  status;", (f"{self.uuid}/%",))
+        results = query_result.fetchall()
+        validation_status_dict = {
+            'VALIDATING': 0,
+            'VALIDATED': 0,
+            'SCHEDULED': 0
+        }
+        if len(results) > 0:
+            for status in results:
+                validation_status_dict[status[0]] = status[1]
+        return validation_status_dict
+
+    def retrieve_file_count_for_upload_area(self):
+        query_result = run_query_with_params("SELECT COUNT(DISTINCT name) FROM file WHERE upload_area_id=%s", self.uuid)
+        results = query_result.fetchall()
+        return results[0][0]
+

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -92,6 +92,21 @@ def retrieve_checksum_status_and_values(upload_area_id: str, filename: str):
 
 
 @return_exceptions_as_http_errors
+def retrieve_validation_status_count(upload_area_id: str):
+    upload_area = _load_upload_area(upload_area_id)
+    status_count = upload_area.retrieve_file_validation_statuses_for_upload_area()
+
+    return status_count, requests.codes.ok
+
+
+@return_exceptions_as_http_errors
+def retrieve_checksum_status_count(upload_area_id: str):
+    upload_area = _load_upload_area(upload_area_id)
+    status_count = upload_area.retrieve_file_checksum_statuses_for_upload_area()
+    return status_count, requests.codes.ok
+
+
+@return_exceptions_as_http_errors
 def update_checksum_event(upload_area_id: str, checksum_id: str, body: str):
     _load_upload_area(upload_area_id)
     body = json.loads(body)


### PR DESCRIPTION
# Need 
* Developers need to be able to check the status of all files in an upload area

# Approach
* query db for status (checksum and validation) of all files in a given upload area
* return a dict of possible statuses and file count

# Testing
* tested sql query on dev db
* unit tests for endpoint