### PR TITLE
namespace csum lambda deployment bucket

### DIFF
--- a/daemons/upload-checksum-daemon/Makefile
+++ b/daemons/upload-checksum-daemon/Makefile
@@ -2,8 +2,8 @@ include ../../common.mk
 .PHONY: install build stage deploy clobber
 
 ZIP_FILE=checksum_daemon.zip
-BUCKET=$(BUCKET_NAME_PREFIX)checksum-lambda-deployment
-STAGED_FILE_KEY=$(DEPLOYMENT_STAGE)/$(ZIP_FILE)
+BUCKET=$(BUCKET_NAME_PREFIX)checksum-lambda-deployment-$(DEPLOYMENT_STAGE)
+STAGED_FILE_KEY=$(ZIP_FILE)
 
 default: build
 

--- a/terraform/modules/upload-service/checksumming_lambda.tf
+++ b/terraform/modules/upload-service/checksumming_lambda.tf
@@ -105,7 +105,7 @@ output "upload_csum_lambda_role_arn" {
 
 
 resource "aws_s3_bucket" "lambda_area_bucket" {
-  bucket = "${var.bucket_name_prefix}checksum-lambda-deployment"
+  bucket = "${var.bucket_name_prefix}checksum-lambda-deployment-${var.deployment_stage}"
   acl = "private"
   force_destroy = "false"
   acceleration_status = "Enabled"
@@ -114,7 +114,7 @@ resource "aws_s3_bucket" "lambda_area_bucket" {
 resource "aws_lambda_function" "upload_checksum_lambda" {
   function_name    = "dcp-upload-csum-${var.deployment_stage}"
   s3_bucket        = "${aws_s3_bucket.lambda_area_bucket.id}"
-  s3_key           = "${var.deployment_stage}/checksum_daemon.zip"
+  s3_key           = "checksum_daemon.zip"
   role             = "arn:aws:iam::${local.account_id}:role/upload-checksum-daemon-${var.deployment_stage}"
   handler          = "app.call_checksum_daemon"
   runtime          = "python3.6"


### PR DESCRIPTION
Need to add the deployment stage to the bucket name (instead of as part of the key inside of the bucket) to allow for prod access