### PR TITLE
Clean up usage of `validation_id` vs. `job_id`

### DIFF
--- a/docker-images/base-alpine-python36/harness.py
+++ b/docker-images/base-alpine-python36/harness.py
@@ -25,8 +25,8 @@ class ValidatorHarness:
 
     def __init__(self):
         self.version = self._find_version()
-        self.validation_id = os.environ['AWS_BATCH_JOB_ID']
-        self.id = os.environ['VALIDATION_ID']
+        self.job_id = os.environ['AWS_BATCH_JOB_ID']
+        self.validation_id = os.environ['VALIDATION_ID']
         self._parse_args()
         key_parts = self.s3_object_key.split('/')
         upload_area_id = key_parts.pop(0)
@@ -36,8 +36,8 @@ class ValidatorHarness:
             version=self.version, attempt=os.environ['AWS_BATCH_JOB_ATTEMPT'], argv=sys.argv))
         self._stage_file_to_be_validated()
         validation_event = UploadedFileValidationEvent(file_id=self.s3_object_key,
-                                                       validation_id=self.id,
-                                                       job_id=self.validation_id,
+                                                       validation_id=self.validation_id,
+                                                       job_id=self.job_id,
                                                        status="VALIDATING")
         if not self.args.test:
             update_event(validation_event, {"upload_area_id": upload_area_id, "name": file_name})
@@ -119,7 +119,7 @@ class ValidatorHarness:
         os.remove(self.staged_file_path)
 
     def _log(self, message):
-        logger.info("[{id}]: ".format(id=self.validation_id) + str(message))
+        logger.info("[{id}]: ".format(id=self.job_id) + str(message))
 
 
 if __name__ == '__main__':

--- a/tests/unit/common/test_uploaded_file.py
+++ b/tests/unit/common/test_uploaded_file.py
@@ -60,9 +60,9 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         uploaded_file = UploadedFile(upload_area=self.upload_area, name="file2#",
                                      content_type="application/octet-stream; dcp-type=data", data="file2_content")
         scheduler = ValidationScheduler(uploaded_file)
-        scheduler.validation_batch_id = "123456"
-        validation_event_id = str(uuid.uuid4())
-        validation_event = scheduler._create_scheduled_validation_event(validation_event_id)
+        scheduler.batch_job_id = "123456"
+        validation_id = str(uuid.uuid4())
+        validation_event = scheduler._create_scheduled_validation_event(validation_id)
         self.assertEqual(validation_event.job_id, "123456")
 
     @patch('upload.common.upload_area.UploadedFile.size', MAX_FILE_SIZE_IN_BYTES - 1)


### PR DESCRIPTION
`validation_id` is now always the self-generated UUID4.
When communication with external entities (passing `VALIDATION_ID`
environment variable to validators, reporting results to Ingest),
always use generated `validation_id`.