### PR TITLE
batch resource path now needs to be asterisk

### DIFF
--- a/terraform/modules/upload-service/api_lambda.tf
+++ b/terraform/modules/upload-service/api_lambda.tf
@@ -84,7 +84,7 @@ resource "aws_iam_role_policy" "upload_api_lambda" {
         "batch:SubmitJob"
       ],
       "Resource": [
-        "arn:aws:batch:*:${local.account_id}:*"
+        "*"
       ]
     },
     {

--- a/terraform/modules/upload-service/checksumming_lambda.tf
+++ b/terraform/modules/upload-service/checksumming_lambda.tf
@@ -69,7 +69,7 @@ resource "aws_iam_role_policy" "upload_csum_lambda" {
         "batch:SubmitJob"
       ],
       "Resource": [
-        "arn:aws:batch:*:${local.account_id}:*"
+        "*"
       ]
     },
     {


### PR DESCRIPTION
Batch does not support resource paths. All batch permissions need resource path of `*`

Message in iam console: The actions in your policy do not support resource-level permissions and require you to choose All resources