### PR TITLE
remove correlation ID from log entries

### DIFF
--- a/upload/common/checksum.py
+++ b/upload/common/checksum.py
@@ -5,7 +5,6 @@ from dcplib.checksumming_io import ChecksummingSink
 from dcplib.s3_multipart import get_s3_multipart_chunk_size, MULTIPART_THRESHOLD
 
 from .logging import get_logger
-from .logging import format_logger_with_id
 from .exceptions import UploadException
 
 logger = get_logger(__name__)
@@ -24,7 +23,6 @@ class UploadedFileChecksummer:
         self.start_time = None
         self.last_diag_output_time = None
         self.multipart_chunksize = get_s3_multipart_chunk_size(self.uploaded_file.s3obj.content_length)
-        format_logger_with_id(logger, "file_key", self.uploaded_file.s3obj.key)
 
     def has_checksums(self):
         return sorted(tuple(self.uploaded_file.checksums.keys())) == sorted(self.CHECKSUM_NAMES)

--- a/upload/common/ingest_notifier.py
+++ b/upload/common/ingest_notifier.py
@@ -6,7 +6,6 @@ import requests
 
 from .exceptions import UploadException
 from .logging import get_logger
-from .logging import format_logger_with_id
 from .database import create_pg_record, update_pg_record
 
 logger = get_logger(__name__)
@@ -45,7 +44,6 @@ class IngestNotifier:
     def format_and_send_notification(self, file_info):
         notification_props = self._format_notification_props(file_info)
         notification_props["status"] = "DELIVERING"
-        format_logger_with_id(logger, "file_key", notification_props["file_id"])
         create_pg_record("notification", notification_props)
         body = json.dumps(file_info)
         success = self._publish_notification(body)

--- a/upload/common/logging.py
+++ b/upload/common/logging.py
@@ -16,10 +16,3 @@ def get_logger(name):
     logger.addHandler(ch)
     logger.setLevel(logging.DEBUG)
     return logger
-
-
-def format_logger_with_id(logger, corr_id_name, corr_id_val):
-    formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s' +
-                                  f' corr_id:{corr_id_name}:{corr_id_val} %(message)s', datefmt="%Y-%m-%dT%H:%M:%S%z")
-    logger.handlers[0].setFormatter(formatter)
-    return logger

--- a/upload/docker_images/checksummer/checksummer.py
+++ b/upload/docker_images/checksummer/checksummer.py
@@ -6,7 +6,6 @@ import sys
 from urllib3.util import parse_url
 from upload.common.upload_area import UploadArea
 from upload.common.logging import get_logger
-from upload.common.logging import format_logger_with_id
 from upload.common.checksum import UploadedFileChecksummer
 from upload.common.checksum_event import UploadedFileChecksumEvent
 from upload.common.upload_api_client import update_event
@@ -49,7 +48,6 @@ class Checksummer:
         url_bits = parse_url(self.args.s3_url)
         self.bucket_name = url_bits.netloc
         self.s3_object_key = url_bits.path.lstrip('/')
-        format_logger_with_id(logger, "file_key", self.s3_object_key)
         logger.debug(f"bucket_name {self.bucket_name}")
         logger.debug(f"s3_object_key {self.s3_object_key}")
 

--- a/upload/docker_images/validator/validator_harness.py
+++ b/upload/docker_images/validator/validator_harness.py
@@ -12,7 +12,6 @@ from tenacity import retry, stop_after_attempt, before_log, before_sleep_log, wa
 
 from upload.common.validation_event import UploadedFileValidationEvent
 from upload.common.logging import get_logger
-from upload.common.logging import format_logger_with_id
 from upload.common.upload_api_client import update_event
 
 
@@ -44,7 +43,6 @@ class ValidatorHarness:
         key_parts = self.s3_object_key.split('/')
         upload_area_id = key_parts.pop(0)
         file_name = "/".join(key_parts)
-        format_logger_with_id(logger, "file_key", self.s3_object_key)
         self._log("VERSION {version}, attempt {attempt} with argv: {argv}".format(
             version=self.version, attempt=os.environ['AWS_BATCH_JOB_ATTEMPT'], argv=sys.argv))
 

--- a/upload/lambdas/api_server/__init__.py
+++ b/upload/lambdas/api_server/__init__.py
@@ -11,7 +11,6 @@ from connexion.lifecycle import ConnexionResponse
 
 from ...common.exceptions import UploadException
 from ...common.logging import get_logger
-from ...common.logging import format_logger_with_id
 
 get_logger('boto3').setLevel(logging.WARNING)
 get_logger('botocore').setLevel(logging.WARNING)
@@ -32,7 +31,6 @@ def return_exceptions_as_http_errors(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
-            _format_logger(kwargs)
             logger.info(f"Running {func} with args={args} kwargs={kwargs}")
             return func(*args, **kwargs)
 
@@ -89,14 +87,3 @@ def rfc7807error_response(title, status, detail=None):
         content_type=RFC7807_MIMETYPE,
         body=body
     )
-
-
-def _format_logger(kwargs):
-    upload_area_id = kwargs.get("upload_area_id")
-    filename = kwargs.get("filename")
-    if upload_area_id:
-        if filename:
-            file_key = upload_area_id + "/" + filename
-            format_logger_with_id(logger, "file_key", file_key)
-        else:
-            format_logger_with_id(logger, "upload_area_id", upload_area_id)

--- a/upload/lambdas/checksum_daemon/checksum_daemon.py
+++ b/upload/lambdas/checksum_daemon/checksum_daemon.py
@@ -13,7 +13,6 @@ from ...common.checksum_event import UploadedFileChecksumEvent
 from ...common.database_orm import db_session_maker, DbChecksum
 from ...common.ingest_notifier import IngestNotifier
 from ...common.logging import get_logger
-from ...common.logging import format_logger_with_id
 from ...common.retry import retry_on_aws_too_many_requests
 from ...common.upload_area import UploadArea
 from ...common.upload_config import UploadConfig, UploadVersion
@@ -38,7 +37,6 @@ class ChecksumDaemon:
 
     def __init__(self, context):
         self.request_id = context.aws_request_id
-        format_logger_with_id(logger, "request_id", self.request_id)
         logger.debug("Ahm ahliiivvve!")
         self.config = UploadConfig()
         self.upload_service_version = UploadVersion().upload_service_version
@@ -71,7 +69,6 @@ class ChecksumDaemon:
                 self._checksum_file()
 
     def _find_file(self, file_key):
-        format_logger_with_id(logger, "file_key", file_key)
         logger.debug(f"File: {file_key}")
         area_uuid = file_key.split('/')[0]
         filename = urllib.parse.unquote(file_key[len(area_uuid) + 1:])


### PR DESCRIPTION
This was a nice idea but never took off, and just makes the log entries too noisy.