### PR TITLE
Refactor: wrap common/database code in a class: UploadDB

### DIFF
--- a/tests/unit/common/test_database.py
+++ b/tests/unit/common/test_database.py
@@ -2,7 +2,7 @@ import uuid
 
 from .. import UploadTestCaseUsingLiveAWS
 
-from upload.common.database import create_pg_record, update_pg_record, get_pg_record
+from upload.common.database import UploadDB
 from upload.common.upload_area import UploadArea
 from upload.common.upload_config import UploadConfig
 
@@ -19,31 +19,32 @@ class TestDatabase(UploadTestCaseUsingLiveAWS):
 
         self.area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.area_id)
+        self.db = UploadDB()
 
-        create_pg_record("upload_area", {
+        self.db.create_pg_record("upload_area", {
             "id": self.area_id,
             "status": "UNLOCKED",
             "bucket_name": self.config.bucket_name
         })
 
     def test_get_pg_record(self):
-        result = get_pg_record("upload_area", self.area_id)
+        result = self.db.get_pg_record("upload_area", self.area_id)
 
         self.assertEqual(result["id"], self.area_id)
         self.assertEqual(result["bucket_name"], self.config.bucket_name)
         self.assertEqual(result["status"], "UNLOCKED")
 
     def test_update_pg_record(self):
-        before = get_pg_record("upload_area", self.area_id)
+        before = self.db.get_pg_record("upload_area", self.area_id)
         self.assertEqual(before["status"], "UNLOCKED")
 
-        update_pg_record("upload_area", {
+        self.db.update_pg_record("upload_area", {
             "id": self.area_id,
             "status": "LOCKED",
             "bucket_name": self.config.bucket_name
         })
 
-        after = get_pg_record("upload_area", self.area_id)
+        after = self.db.get_pg_record("upload_area", self.area_id)
         self.assertEqual(after["id"], self.area_id)
         self.assertEqual(after["bucket_name"], self.config.bucket_name)
         self.assertEqual(after["status"], "LOCKED")

--- a/tests/unit/lambdas/api_server/test_health.py
+++ b/tests/unit/lambdas/api_server/test_health.py
@@ -1,9 +1,6 @@
 from . import client_for_test_api_server
 from ... import UploadTestCaseUsingMockAWS, EnvironmentSetup
 
-# The following line is a HACK to stop database.yml opening a connection when file upload-api.yml is read.
-from upload.common.database import get_pg_record
-
 
 class TestHealthcheckEndpoint(UploadTestCaseUsingMockAWS):
 

--- a/tests/unit/lambdas/api_server/test_upload_api_client.py
+++ b/tests/unit/lambdas/api_server/test_upload_api_client.py
@@ -14,7 +14,7 @@ from upload.common.uploaded_file import UploadedFile
 from upload.common.upload_area import UploadArea
 from upload.common.validation_event import UploadedFileValidationEvent
 from upload.common.checksum_event import UploadedFileChecksumEvent
-from upload.common.database import get_pg_record
+from upload.common.database import UploadDB
 
 if __name__ == '__main__':
     pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
@@ -65,7 +65,7 @@ class TestDatabase(UploadTestCaseUsingMockAWS):
         validation_event.status = "VALIDATING"
         response = update_event(validation_event, uploaded_file.info(), self.client)
         self.assertEqual(response.status_code, 204)
-        record = get_pg_record("validation", validation_id)
+        record = UploadDB().get_pg_record("validation", validation_id)
         self.assertEqual(record["status"], "VALIDATING")
         self.assertEqual(str(type(record.get("validation_started_at"))), "<class 'datetime.datetime'>")
         self.assertEqual(record["validation_ended_at"], None)
@@ -74,7 +74,7 @@ class TestDatabase(UploadTestCaseUsingMockAWS):
         validation_event.status = "VALIDATED"
         response = update_event(validation_event, uploaded_file.info(), self.client)
         self.assertEqual(response.status_code, 204)
-        record = get_pg_record("validation", validation_id)
+        record = UploadDB().get_pg_record("validation", validation_id)
         self.assertEqual(record["status"], "VALIDATED")
         self.assertEqual(str(type(record.get("validation_started_at"))), "<class 'datetime.datetime'>")
         self.assertEqual(str(type(record.get("validation_ended_at"))), "<class 'datetime.datetime'>")
@@ -98,7 +98,7 @@ class TestDatabase(UploadTestCaseUsingMockAWS):
         checksum_event.status = "CHECKSUMMING"
         response = update_event(checksum_event, uploaded_file.info(), self.client)
         self.assertEqual(response.status_code, 204)
-        record = get_pg_record("checksum", checksum_id)
+        record = UploadDB().get_pg_record("checksum", checksum_id)
         self.assertEqual(record["status"], "CHECKSUMMING")
         self.assertEqual(str(type(record.get("checksum_started_at"))), "<class 'datetime.datetime'>")
         self.assertEqual(record["checksum_ended_at"], None)
@@ -106,7 +106,7 @@ class TestDatabase(UploadTestCaseUsingMockAWS):
         checksum_event.status = "CHECKSUMMED"
         response = update_event(checksum_event, uploaded_file.info(), self.client)
         self.assertEqual(response.status_code, 204)
-        record = get_pg_record("checksum", checksum_id)
+        record = UploadDB().get_pg_record("checksum", checksum_id)
         self.assertEqual(record["status"], "CHECKSUMMED")
         self.assertEqual(str(type(record.get("checksum_started_at"))), "<class 'datetime.datetime'>")
         self.assertEqual(str(type(record.get("checksum_ended_at"))), "<class 'datetime.datetime'>")

--- a/tests/unit/lambdas/api_server/test_validation_api.py
+++ b/tests/unit/lambdas/api_server/test_validation_api.py
@@ -9,7 +9,7 @@ from upload.common.upload_area import UploadArea
 from upload.common.uploaded_file import UploadedFile
 from upload.common.validation_event import UploadedFileValidationEvent
 from upload.lambdas.api_server.validation_scheduler import MAX_FILE_SIZE_IN_BYTES
-from upload.common.database import get_pg_record
+from upload.common.database import UploadDB
 
 from . import client_for_test_api_server
 from ... import UploadTestCaseUsingMockAWS, EnvironmentSetup
@@ -202,7 +202,7 @@ class TestValidationApi(UploadTestCaseUsingMockAWS):
                                     headers=self.authentication_header,
                                     data=json.dumps(data))
         self.assertEqual(204, response.status_code)
-        record = get_pg_record("validation", validation_id)
+        record = UploadDB().get_pg_record("validation", validation_id)
         self.assertEqual("test_docker_image", record["docker_image"])
         self.assertEqual(validation_id, record["id"])
         self.assertEqual(orig_val_id, record["original_validation_id"])
@@ -256,7 +256,7 @@ class TestValidationApi(UploadTestCaseUsingMockAWS):
             'url': f"s3://{self.upload_config.bucket_name}/{area_id}/foo.json",
             'checksums': {'s3_etag': '1', 'sha1': '2', 'sha256': '3', 'crc32c': '4'}
         })
-        record = get_pg_record("validation", validation_id)
+        record = UploadDB().get_pg_record("validation", validation_id)
         self.assertEqual("VALIDATED", record["status"])
         self.assertEqual("test_docker_image", record["docker_image"])
         self.assertEqual("<class 'datetime.datetime'>", str(type(record.get("validation_started_at"))))

--- a/tests/unit/lambdas/test_batch_watcher.py
+++ b/tests/unit/lambdas/test_batch_watcher.py
@@ -32,7 +32,7 @@ class TestBatchWatcherDaemon(UploadTestCaseUsingMockAWS):
         self.environmentor.exit()
         super().tearDown()
 
-    @patch('upload.lambdas.batch_watcher.batch_watcher.run_query')
+    @patch('upload.lambdas.batch_watcher.batch_watcher.UploadDB.run_query')
     def test_find_incomplete_batch_jobs(self, mock_run_query):
         mock_run_query.return_value = QueryResult()
         csum_jobs, val_jobs = self.batch_watcher.find_incomplete_batch_jobs()
@@ -68,7 +68,7 @@ class TestBatchWatcherDaemon(UploadTestCaseUsingMockAWS):
         killed_instance_ids = self.batch_watcher.find_and_kill_deployment_batch_instances()
         self.assertEqual(killed_instance_ids, instance_ids)
 
-    @patch('upload.lambdas.batch_watcher.batch_watcher.run_query_with_params')
+    @patch('upload.lambdas.batch_watcher.batch_watcher.UploadDB.run_query_with_params')
     @patch('upload.lambdas.batch_watcher.batch_watcher.BatchWatcher.schedule_validation_job')
     def test_schedule_job_with_validation(self, mock_schedule_validation_job, mock_run_query):
         row = {
@@ -91,7 +91,7 @@ class TestBatchWatcherDaemon(UploadTestCaseUsingMockAWS):
         self.batch_watcher.schedule_job(row, "validation")
         mock_schedule_validation_job.assert_called_with("test_area", "test_id", "test_docker_image", "123")
 
-    @patch('upload.lambdas.batch_watcher.batch_watcher.run_query_with_params')
+    @patch('upload.lambdas.batch_watcher.batch_watcher.UploadDB.run_query_with_params')
     @patch('upload.lambdas.batch_watcher.batch_watcher.BatchWatcher.invoke_checksum_lambda')
     def test_schedule_job_with_checksum(self, mock_invoke_csum_lambda, mock_run_query):
         row = {

--- a/tests/unit/lambdas/test_batch_watcher.py
+++ b/tests/unit/lambdas/test_batch_watcher.py
@@ -20,11 +20,17 @@ class TestBatchWatcherDaemon(UploadTestCaseUsingMockAWS):
             'DEPLOYMENT_STAGE': 'test',
             'API_KEY': 'test'
         }
-        EnvironmentSetup(self.environment)
+        self.environmentor = EnvironmentSetup(self.environment)
+        self.environmentor.enter()
+
         self.batch_watcher = BatchWatcher()
         self.mock_batch_client = Stubber(self.batch_watcher.batch_client)
         self.mock_ec2_client = Stubber(self.batch_watcher.ec2_client)
         self.mock_lambda_client = Stubber(self.batch_watcher.lambda_client)
+
+    def tearDown(self):
+        self.environmentor.exit()
+        super().tearDown()
 
     @patch('upload.lambdas.batch_watcher.batch_watcher.run_query')
     def test_find_incomplete_batch_jobs(self, mock_run_query):

--- a/tests/unit/lambdas/test_health_check.py
+++ b/tests/unit/lambdas/test_health_check.py
@@ -306,7 +306,7 @@ class TestHealthCheckDaemon(UploadTestCaseUsingMockAWS):
         assert deadletter_dict == {'visible_messages': 'no value returned', 'received_messages': 'no value returned'}
         stubber.deactivate()
 
-    @patch('upload.lambdas.health_check.health_check.run_query')
+    @patch('upload.lambdas.health_check.health_check.UploadDB.run_query')
     def test_query_db_and_return_first_row_queries_db_and_handles_expected_db_response(self, mock_run_query):
         mock_run_query.return_value = MockIt()
         area_count = self.health_check._query_db_and_return_first_row("SELECT COUNT(*) FROM checksum ")

--- a/upload/common/checksum_event.py
+++ b/upload/common/checksum_event.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from .logging import get_logger
 if not os.environ.get("CONTAINER"):
-    from .database import create_pg_record, update_pg_record
+    from .database import UploadDB
 
 logger = get_logger(__name__)
 
@@ -15,6 +15,7 @@ class UploadedFileChecksumEvent:
         self.file_id = kwargs["file_id"]
         self.status = kwargs["status"]
         self.checksums = None
+        self.db = UploadDB()
 
     def _format_prop_vals_dict(self):
         vals_dict = {
@@ -34,8 +35,8 @@ class UploadedFileChecksumEvent:
 
     def create_record(self):
         prop_vals_dict = self._format_prop_vals_dict()
-        create_pg_record("checksum", prop_vals_dict)
+        self.db.create_pg_record("checksum", prop_vals_dict)
 
     def update_record(self):
         prop_vals_dict = self._format_prop_vals_dict()
-        update_pg_record("checksum", prop_vals_dict)
+        self.db.update_pg_record("checksum", prop_vals_dict)

--- a/upload/common/database.py
+++ b/upload/common/database.py
@@ -8,81 +8,92 @@ from sqlalchemy.exc import OperationalError, IntegrityError, DatabaseError
 from .exceptions import UploadException
 from .upload_config import UploadDbConfig
 
-config = UploadDbConfig()
-engine = create_engine(config.pgbouncer_uri, pool_size=1)
-meta = MetaData(engine, reflect=True)
-record_type_table_map = {
-    "upload_area": meta.tables['upload_area'],
-    "file": meta.tables['file'],
-    "notification": meta.tables['notification'],
-    "validation": meta.tables['validation'],
-    "checksum": meta.tables['checksum']
-}
 
+class UploadDB:
 
-def create_pg_record(record_type, prop_vals_dict):
-    prop_vals_dict["created_at"] = datetime.utcnow()
-    prop_vals_dict["updated_at"] = datetime.utcnow()
-    table = record_type_table_map[record_type]
-    ins = table.insert().values(prop_vals_dict)
-    try:
-        run_query(ins)
-    except IntegrityError as e:
-        if re.search("duplicate key value violates unique constraint", e.orig.pgerror):
-            raise UploadException(status=requests.codes.conflict,
-                                  title=f"{record_type} Already Exists",
-                                  detail=f"{record_type} {prop_vals_dict['id']} already exists")
+    _engine = None
+    _record_type_table_map = None
+
+    def __init__(self):
+        if self.record_type_table_map is None:
+            config = UploadDbConfig()
+            self.__class__._engine = create_engine(config.pgbouncer_uri, pool_size=1)
+            meta = MetaData(self.engine, reflect=True)
+            self.__class__._record_type_table_map = {
+                "upload_area": meta.tables['upload_area'],
+                "file": meta.tables['file'],
+                "notification": meta.tables['notification'],
+                "validation": meta.tables['validation'],
+                "checksum": meta.tables['checksum']
+            }
+
+    @property
+    def engine(self):
+        return self.__class__._engine
+
+    @property
+    def record_type_table_map(self):
+        return self.__class__._record_type_table_map
+
+    def create_pg_record(self, record_type, prop_vals_dict):
+        prop_vals_dict["created_at"] = datetime.utcnow()
+        prop_vals_dict["updated_at"] = datetime.utcnow()
+        table = self.record_type_table_map[record_type]
+        ins = table.insert().values(prop_vals_dict)
+        try:
+            self.run_query(ins)
+        except IntegrityError as e:
+            if re.search("duplicate key value violates unique constraint", e.orig.pgerror):
+                raise UploadException(status=requests.codes.conflict,
+                                      title=f"{record_type} Already Exists",
+                                      detail=f"{record_type} {prop_vals_dict['id']} already exists")
+            else:
+                raise e
+
+    def update_pg_record(self, record_type, prop_vals_dict):
+        record_id = prop_vals_dict["id"]
+        del prop_vals_dict["id"]
+        prop_vals_dict["updated_at"] = datetime.utcnow()
+        table = self.record_type_table_map[record_type]
+        update = table.update().where(table.c.id == record_id).values(prop_vals_dict)
+        self.run_query(update)
+
+    def get_pg_record(self, record_type, record_id):
+        table = self.record_type_table_map[record_type]
+        select = table.select().where(table.c.id == record_id)
+        result = self.run_query(select)
+        column_keys = result.keys()
+        rows = result.fetchall()
+        if len(rows) == 0:
+            return None
+        elif len(rows) > 1:
+            raise RuntimeError(f"There is more than 1 {record_type} with ID {record_id}!")
         else:
-            raise e
+            output = {}
+            for idx, val in enumerate(rows[0]):
+                column = column_keys[idx]
+                output[column] = val
+            return output
 
+    # Engine.dispose() protects us from situations where the client thinks it has
+    # an active connection but for some reason it is inactive. Potential causes
+    # include network issues or pgbouncer dropping inactive client connections after
+    # a long idle timeout. Sometimes its difficult to determine how long AWS actually
+    # keeps old lambda containers warmed up and waiting. This code path should not be
+    # followed often, but it is a good protective measure.
 
-def update_pg_record(record_type, prop_vals_dict):
-    record_id = prop_vals_dict["id"]
-    del prop_vals_dict["id"]
-    prop_vals_dict["updated_at"] = datetime.utcnow()
-    table = record_type_table_map[record_type]
-    update = table.update().where(table.c.id == record_id).values(prop_vals_dict)
-    run_query(update)
+    def run_query(self, query):
+        try:
+            results = self.engine.execute(query)
+        except (OperationalError, DatabaseError) as e:
+            self.engine.dispose()
+            results = self.engine.execute(query)
+        return results
 
-
-def get_pg_record(record_type, record_id):
-    table = record_type_table_map[record_type]
-    select = table.select().where(table.c.id == record_id)
-    result = run_query(select)
-    column_keys = result.keys()
-    rows = result.fetchall()
-    if len(rows) == 0:
-        return None
-    elif len(rows) > 1:
-        raise RuntimeError(f"There is more than 1 {record_type} with ID {record_id}!")
-    else:
-        output = {}
-        for idx, val in enumerate(rows[0]):
-            column = column_keys[idx]
-            output[column] = val
-        return output
-
-
-# Engine.dispose() protects us from situations where the client thinks it has
-# an active connection but for some reason it is inactive. Potential causes
-# include network issues or pgbouncer dropping inactive client connections after
-# a long idle timeout. Sometimes its difficult to determine how long AWS actually
-# keeps old lambda containers warmed up and waiting. This code path should not be
-# followed often, but it is a good protective measure.
-
-def run_query(query):
-    try:
-        results = engine.execute(query)
-    except (OperationalError, DatabaseError) as e:
-        engine.dispose()
-        results = engine.execute(query)
-    return results
-
-
-def run_query_with_params(query, params):
-    try:
-        results = engine.execute(query, params)
-    except (OperationalError, DatabaseError) as e:
-        engine.dispose()
-        results = engine.execute(query, params)
-    return results
+    def run_query_with_params(self, query, params):
+        try:
+            results = self.engine.execute(query, params)
+        except (OperationalError, DatabaseError) as e:
+            self.engine.dispose()
+            results = self.engine.execute(query, params)
+        return results

--- a/upload/common/database_orm.py
+++ b/upload/common/database_orm.py
@@ -65,7 +65,14 @@ DbUploadArea.files = relationship('DbFile', order_by=DbFile.id, back_populates='
 DbFile.checksums = relationship('DbChecksum', order_by=DbChecksum.created_at, back_populates='file')
 DbFile.validations = relationship('DbValidation', order_by=DbValidation.created_at, back_populates='file')
 
-engine = create_engine(UploadDbConfig().database_uri)
-Base.metadata.bind = engine
-db_session_maker = sessionmaker()
-db_session_maker.bind = engine
+
+class DBSessionMaker:
+
+    def __init__(self):
+        engine = create_engine(UploadDbConfig().database_uri)
+        Base.metadata.bind = engine
+        self.session_maker = sessionmaker()
+        self.session_maker.bind = engine
+
+    def session(self):
+        return self.session_maker()

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -14,7 +14,7 @@ from .upload_config import UploadConfig
 from .logging import get_logger
 
 if not os.environ.get("CONTAINER"):
-    from .database import get_pg_record, create_pg_record, update_pg_record, run_query_with_params
+    from .database import UploadDB
 
 logger = get_logger(__name__)
 
@@ -30,6 +30,7 @@ class UploadArea:
         self.key_prefix = f"{self.uuid}/"
         self.key_prefix_length = len(self.key_prefix)
         self._bucket = s3.Bucket(self.bucket_name)
+        self.db = UploadDB()
 
     @property
     def bucket_name(self):
@@ -139,7 +140,7 @@ class UploadArea:
         return UploadedFile.from_s3_key(self, key)
 
     def is_extant(self) -> bool:
-        record = get_pg_record('upload_area', self.uuid)
+        record = self.db.get_pg_record('upload_area', self.uuid)
         if record and record['status'] != 'DELETED':
             return True
         else:
@@ -170,15 +171,15 @@ class UploadArea:
         }
 
     def _db_record(self):
-        return get_pg_record('upload_area', self.uuid)
+        return self.db.get_pg_record('upload_area', self.uuid)
 
     def _create_record(self):
         prop_vals_dict = self._format_prop_vals_dict()
-        create_pg_record("upload_area", prop_vals_dict)
+        self.db.create_pg_record("upload_area", prop_vals_dict)
 
     def _update_record(self):
         prop_vals_dict = self._format_prop_vals_dict()
-        update_pg_record("upload_area", prop_vals_dict)
+        self.db.update_pg_record("upload_area", prop_vals_dict)
 
     def retrieve_file_checksum_statuses_for_upload_area(self):
         checksum_status = {
@@ -187,8 +188,8 @@ class UploadArea:
             'CHECKSUMMED': 0,
             'CHECKSUMMING_UNSCHEDULED': 0
         }
-        query_result = run_query_with_params("SELECT status, COUNT(DISTINCT checksum.file_id) FROM checksum "
-                                             "WHERE file_id LIKE %s GROUP BY  status;", (f"{self.uuid}/%",))
+        query_result = self.db.run_query_with_params("SELECT status, COUNT(DISTINCT checksum.file_id) FROM checksum "
+                                                     "WHERE file_id LIKE %s GROUP BY  status;", (f"{self.uuid}/%",))
         results = query_result.fetchall()
         checksumming_file_count = 0
         if len(results) > 0:
@@ -199,8 +200,8 @@ class UploadArea:
         return checksum_status
 
     def retrieve_file_validation_statuses_for_upload_area(self):
-        query_result = run_query_with_params("SELECT status, COUNT(DISTINCT validation.file_id) FROM validation "
-                                             "WHERE file_id LIKE %s GROUP BY  status;", (f"{self.uuid}/%",))
+        query_result = self.db.run_query_with_params("SELECT status, COUNT(DISTINCT validation.file_id) FROM validation"
+                                                     " WHERE file_id LIKE %s GROUP BY  status;", (f"{self.uuid}/%",))
         results = query_result.fetchall()
         validation_status_dict = {
             'VALIDATING': 0,
@@ -213,6 +214,7 @@ class UploadArea:
         return validation_status_dict
 
     def retrieve_file_count_for_upload_area(self):
-        query_result = run_query_with_params("SELECT COUNT(DISTINCT name) FROM file WHERE upload_area_id=%s", self.uuid)
+        query_result = self.db.run_query_with_params("SELECT COUNT(DISTINCT name) FROM file WHERE upload_area_id=%s",
+                                                     self.uuid)
         results = query_result.fetchall()
         return results[0][0]

--- a/upload/common/validation_event.py
+++ b/upload/common/validation_event.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from .logging import get_logger
 if not os.environ.get("CONTAINER"):
-    from .database import create_pg_record, update_pg_record
+    from .database import UploadDB
 
 logger = get_logger(__name__)
 
@@ -17,6 +17,7 @@ class UploadedFileValidationEvent:
         self.status = kwargs["status"]
         self.docker_image = kwargs.get("docker_image")
         self.original_validation_id = kwargs.get("original_validation_id")
+        self.db = UploadDB()
 
     def _format_prop_vals_dict(self):
         vals_dict = {
@@ -41,8 +42,8 @@ class UploadedFileValidationEvent:
 
     def create_record(self):
         prop_vals_dict = self._format_prop_vals_dict()
-        create_pg_record("validation", prop_vals_dict)
+        self.db.create_pg_record("validation", prop_vals_dict)
 
     def update_record(self):
         prop_vals_dict = self._format_prop_vals_dict()
-        update_pg_record("validation", prop_vals_dict)
+        self.db.update_pg_record("validation", prop_vals_dict)

--- a/upload/lambdas/checksum_daemon/checksum_daemon.py
+++ b/upload/lambdas/checksum_daemon/checksum_daemon.py
@@ -10,7 +10,7 @@ from six.moves import urllib
 from ...common.batch import JobDefinition
 from ...common.checksum import UploadedFileChecksummer
 from ...common.checksum_event import UploadedFileChecksumEvent
-from ...common.database_orm import db_session_maker, DbChecksum
+from ...common.database_orm import DBSessionMaker, DbChecksum
 from ...common.ingest_notifier import IngestNotifier
 from ...common.logging import get_logger
 from ...common.retry import retry_on_aws_too_many_requests
@@ -113,7 +113,7 @@ class ChecksumDaemon:
 
     def _find_checksum_status_of_event_newer_than_file_last_modified(self, file_key):
         checksum_status = None
-        db_session = db_session_maker()
+        db_session = DBSessionMaker().session()
         checksums = db_session.query(DbChecksum).filter(DbChecksum.file_id == file_key).all()
         for csum in checksums:
             if csum.status == "CHECKSUMMED" and csum.updated_at >= self.uploaded_file.s3obj.last_modified:

--- a/upload/lambdas/health_check/health_check.py
+++ b/upload/lambdas/health_check/health_check.py
@@ -5,7 +5,7 @@ import os
 import boto3
 import requests
 
-from upload.common.database import run_query
+from upload.common.database import UploadDB
 from upload.common.logging import get_logger
 from upload.common.upload_config import UploadConfig
 
@@ -17,6 +17,7 @@ client = boto3.client('cloudwatch')
 class HealthCheck:
     def __init__(self):
         self.env = os.environ['DEPLOYMENT_STAGE']
+        self.db = UploadDB()
         logger.debug(f"Running a health check for {self.env}. Results will be posted in #upload-service")
         self.webhook = UploadConfig().slack_webhook
 
@@ -180,7 +181,7 @@ class HealthCheck:
         return results
 
     def _query_db_and_return_first_row(self, query):
-        query_result = run_query(query)
+        query_result = self.db.run_query(query)
         rows = query_result.fetchall()
         if len(rows) > 0:
             results = rows[0][0]


### PR DESCRIPTION
Having the database initialization done in an __init__ method instead
of at file parse time makes it easier to change configuration for
testing purposes.

However, calling Metadata() takes about 7 seconds, so we don't want
to do it a lot.  For this reason we store the engine and record_type_table_map
in class variables.