### PR TITLE
add post /area/file endpoint that adds file payload to pre checksum sqs

### DIFF
--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -332,6 +332,35 @@ paths:
 
   /v1/area/{upload_area_id}/{filename}:
 
+    post:
+      summary: Notify upload of uploaded file
+      operationId: upload.lambdas.api_server.v1.area.post_file
+      description: Notify upload api of uploaded file in upload area.
+      tags:
+        - All
+      parameters:
+        - name: upload_area_id
+          in: path
+          description: A RFC4122-compliant ID for the upload area.
+          required: true
+          type: string
+        - name: filename
+          in: path
+          description: Name of file uploaded in upload area.
+          required: true
+          type: string
+      responses:
+        202:
+          description: File upload notification added to queue
+        404:
+          description: Could not find that upload area.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
     put:
       summary: Store a metadata file
       operationId: upload.lambdas.api_server.v1.area.put_file

--- a/terraform/modules/upload-service/secrets.tf
+++ b/terraform/modules/upload-service/secrets.tf
@@ -10,6 +10,7 @@ resource "aws_secretsmanager_secret_version" "secrets" {
   "validation_job_q_arn": "${aws_batch_job_queue.validation_job_q.arn}",
   "validation_job_role_arn": "${aws_iam_role.validation_job_role.arn}",
   "csum_job_q_arn": "${aws_batch_job_queue.csum_job_q.arn}",
+  "csum_job_q_url": "${aws_batch_job_queue.csum_job_q.url}",
   "csum_job_role_arn": "${aws_iam_role.csum_job_role.arn}",
   "upload_submitter_role_arn": "${aws_iam_role.upload_submitter.arn}",
   "api_key": "${var.ingest_api_key}",

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 import boto3
-from moto import mock_iam, mock_s3, mock_sts
+from moto import mock_iam, mock_s3, mock_sts, mock_sqs
 
 from upload.common.upload_config import UploadConfig
 
@@ -62,14 +62,17 @@ class UploadTestCaseUsingMockAWS(unittest.TestCase):
         self.iam_mock.start()
         self.sts_mock = mock_sts()
         self.sts_mock.start()
+        self.sqs_mock = mock_sqs()
+        self.sqs_mock.start()
         # UploadConfig
         self.upload_config = UploadConfig()
         self.upload_config.set({
             'bucket_name': 'bogobucket',
             'csum_job_q_arn': 'bogo_arn',
+            'csum_job_q_url': 'bogo_url',
             'csum_job_role_arn': 'bogo_role_arn',
             'upload_submitter_role_arn': 'bogo_submitter_role_arn',
-            'slack_webhook': 'bogo_slack_url'
+            'slack_webhook': 'bogo_slack_url',
         })
         # Common Environment
         self.deployment_stage = 'test'
@@ -81,6 +84,9 @@ class UploadTestCaseUsingMockAWS(unittest.TestCase):
         # Upload Bucket
         self.upload_bucket = boto3.resource('s3').Bucket(self.upload_config.bucket_name)
         self.upload_bucket.create()
+
+        self.sqs = boto3.resource('sqs')
+        self.sqs.create_queue(QueueName=f"bogo_url")
 
     def tearDown(self):
         self.s3_mock.stop()

--- a/tests/unit/common/test_database.py
+++ b/tests/unit/common/test_database.py
@@ -15,6 +15,7 @@ class TestDatabase(UploadTestCaseUsingLiveAWS):
         self.config = UploadConfig()
         self.config.set({
             'bucket_name': "test_bucket_name",
+            'csum_job_q_url': "bogo_url"
         })
 
         self.area_id = str(uuid.uuid4())

--- a/tests/unit/lambdas/api_server/test_area.py
+++ b/tests/unit/lambdas/api_server/test_area.py
@@ -351,6 +351,32 @@ class TestAreaApi(UploadTestCaseUsingMockAWS):
             'checksums': {'s3_etag': 'a', 'sha1': 'b', 'sha256': 'c', 'crc32c': 'd'}
         })
 
+    def test_post_file_with_valid_area(self):
+        area_id = self._create_area()
+        response = self.client.post(f"/v1/area/{area_id}/filename123")
+        message = self.sqs.meta.client.receive_message(QueueUrl='bogo_url')
+        message_body = json.loads(message['Messages'][0]['Body'])
+        s3_key = message_body['Records'][0]['s3']['object']['key']
+        s3_bucket = message_body['Records'][0]['s3']['bucket']['name']
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(s3_key, f"{area_id}/filename123")
+        self.assertEqual(s3_bucket, "bogobucket")
+
+    def test_post_file_with_invalid_area(self):
+        area_id = str(uuid.uuid4())
+        response = self.client.post(f"/v1/area/{area_id}/filename123")
+        self.assertEqual(404, response.status_code)
+
+    def test_add_uploaded_file_to_csum_daemon_sqs(self):
+        area_id = self._create_area()
+        UploadArea(area_id).add_uploaded_file_to_csum_daemon_sqs("filename123")
+        message = self.sqs.meta.client.receive_message(QueueUrl='bogo_url')
+        message_body = json.loads(message['Messages'][0]['Body'])
+        s3_key = message_body['Records'][0]['s3']['object']['key']
+        s3_bucket = message_body['Records'][0]['s3']['bucket']['name']
+        self.assertEqual(s3_key, f"{area_id}/filename123")
+        self.assertEqual(s3_bucket, "bogobucket")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/lambdas/api_server/test_area.py
+++ b/tests/unit/lambdas/api_server/test_area.py
@@ -353,8 +353,10 @@ class TestAreaApi(UploadTestCaseUsingMockAWS):
 
     def test_post_file_with_valid_area(self):
         area_id = self._create_area()
+
         response = self.client.post(f"/v1/area/{area_id}/filename123")
         message = self.sqs.meta.client.receive_message(QueueUrl='bogo_url')
+
         message_body = json.loads(message['Messages'][0]['Body'])
         s3_key = message_body['Records'][0]['s3']['object']['key']
         s3_bucket = message_body['Records'][0]['s3']['bucket']['name']
@@ -369,8 +371,10 @@ class TestAreaApi(UploadTestCaseUsingMockAWS):
 
     def test_add_uploaded_file_to_csum_daemon_sqs(self):
         area_id = self._create_area()
+
         UploadArea(area_id).add_uploaded_file_to_csum_daemon_sqs("filename123")
         message = self.sqs.meta.client.receive_message(QueueUrl='bogo_url')
+
         message_body = json.loads(message['Messages'][0]['Body'])
         s3_key = message_body['Records'][0]['s3']['object']['key']
         s3_bucket = message_body['Records'][0]['s3']['bucket']['name']

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -3,6 +3,7 @@ import os
 import uuid
 
 import boto3
+from tenacity import retry, wait_fixed, stop_after_attempt
 
 from dcplib.media_types import DcpMediaType
 
@@ -19,6 +20,7 @@ if not os.environ.get("CONTAINER"):
 logger = get_logger(__name__)
 
 s3 = boto3.resource('s3')
+sqs = boto3.resource('sqs')
 
 
 class UploadArea:
@@ -30,6 +32,7 @@ class UploadArea:
         self.key_prefix = f"{self.uuid}/"
         self.key_prefix_length = len(self.key_prefix)
         self._bucket = s3.Bucket(self.bucket_name)
+        self.csum_sqs_url = self.config.csum_job_q_url
 
     @property
     def bucket_name(self):
@@ -110,6 +113,27 @@ class UploadArea:
 
     def s3_object_for_file(self, filename):
         return self._bucket.Object(self.key_prefix + filename)
+
+    @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
+    def add_uploaded_file_to_csum_daemon_sqs(self, filename):
+        payload = {
+            'Records': [{
+                'eventName': 'ObjectCreated:Put',
+                "s3": {
+                    "bucket": {
+                        "name": f"{self.bucket_name}"
+                    },
+                    "object": {
+                        "key": f"{self.key_prefix}{filename}"
+                    }
+                }
+            }]
+        }
+        response = sqs.meta.client.send_message(QueueUrl=self.csum_sqs_url, MessageBody=json.dumps(payload))
+        status = response['ResponseMetadata']['HTTPStatusCode']
+        if status != 200:
+            raise UploadException(f"Adding file upload message for {self.key_prefix}{filename} \
+                                    was unsuccessful to sqs {self.csum_job_q_url} )")
 
     def store_file(self, filename, content, content_type):
         media_type = DcpMediaType.from_string(content_type)

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -68,6 +68,13 @@ def put_file(upload_area_id: str, filename: str, body: str):
 
 
 @return_exceptions_as_http_errors
+def post_file(upload_area_id: str, filename: str):
+    upload_area = _load_upload_area(upload_area_id)
+    upload_area.add_uploaded_file_to_csum_daemon_sqs(filename)
+    return None, requests.codes.accepted
+
+
+@return_exceptions_as_http_errors
 @require_authenticated
 def schedule_file_validation(upload_area_id: str, filename: str, json_request_body: str):
     upload_area = _load_upload_area(upload_area_id)


### PR DESCRIPTION
This PR is relevant to ticket https://github.com/HumanCellAtlas/upload-service/issues/227. It accomplishes the first bullet point: `Post /area/file endpoint in upload api that adds file payload to pre-csum sqs`. Steps 2 and 3 remain and are dependent on this api change being promoted through all environments.