### PR TITLE
remove link between s3 and sqs

### DIFF
--- a/terraform/modules/upload-service/bucket.tf
+++ b/terraform/modules/upload-service/bucket.tf
@@ -37,15 +37,6 @@ resource "aws_iam_policy" "upload_areas_submitter_access" {
 POLICY
 }
 
-resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${aws_s3_bucket.upload_areas_bucket.id}"
-
-  queue {
-    queue_arn     = "${aws_sqs_queue.upload_queue.arn}"
-    events        = ["s3:ObjectCreated:*"]
-  }
-}
-
 locals {
   # The ARN of the principal of the running API Lambda
   api_lambda_principal_arn = "arn:aws:sts::${local.account_id}:assumed-role/${aws_iam_role.upload_api_lambda.name}/${aws_lambda_function.upload_api_lambda.function_name}"


### PR DESCRIPTION
This is related to point # 3 in ticket https://github.com/HumanCellAtlas/upload-service/issues/227: `Remove link between s3 and sqs`. Sqs will now be fed directly via calls to the upload api from the hca cli. This is not to be merged in until the api change (https://github.com/HumanCellAtlas/upload-service/pull/243) has been promoted through all environments and changes to hca cli have been made with new version cut.