### PR TITLE
Increase csum memory

### DIFF
--- a/terraform/modules/upload-service/checksumming_lambda.tf
+++ b/terraform/modules/upload-service/checksumming_lambda.tf
@@ -111,7 +111,7 @@ resource "aws_lambda_function" "upload_checksum_lambda" {
   role             = "arn:aws:iam::${local.account_id}:role/upload-checksum-daemon-${var.deployment_stage}"
   handler          = "app.call_checksum_daemon"
   runtime          = "python3.6"
-  memory_size      = 960
+  memory_size      = 1500
   timeout          = 900
 
   environment {


### PR DESCRIPTION
Cloudwatch insights suggest that we are routinely bumping into the 960mb limit in staging and production. This PR bumps it up to 1500mb. I will reanalyze the memory consumption after a few months.