### PR TITLE
Many kinds of cleanup

### DIFF
--- a/tests/unit/common/test_database.py
+++ b/tests/unit/common/test_database.py
@@ -11,15 +11,6 @@ class TestDatabase(UploadTestCaseUsingLiveAWS):
 
     def setUp(self):
         super().setUp()
-        # Config
-        self.config = UploadConfig()
-        self.config.set({
-            'bucket_name': "test_bucket_name",
-            'csum_upload_q_url': "bogo_url",
-            'area_deletion_q_url': "delete_sqs_url",
-            'area_deletion_lambda_name': "delete_lambda_name"
-        })
-
         self.area_id = str(uuid.uuid4())
         self.upload_area = UploadArea(self.area_id)
         self.db = UploadDB()
@@ -27,14 +18,14 @@ class TestDatabase(UploadTestCaseUsingLiveAWS):
         self.db.create_pg_record("upload_area", {
             "id": self.area_id,
             "status": "UNLOCKED",
-            "bucket_name": self.config.bucket_name
+            "bucket_name": self.upload_config.bucket_name
         })
 
     def test_get_pg_record(self):
         result = self.db.get_pg_record("upload_area", self.area_id)
 
         self.assertEqual(result["id"], self.area_id)
-        self.assertEqual(result["bucket_name"], self.config.bucket_name)
+        self.assertEqual(result["bucket_name"], self.upload_config.bucket_name)
         self.assertEqual(result["status"], "UNLOCKED")
 
     def test_update_pg_record(self):
@@ -44,10 +35,10 @@ class TestDatabase(UploadTestCaseUsingLiveAWS):
         self.db.update_pg_record("upload_area", {
             "id": self.area_id,
             "status": "LOCKED",
-            "bucket_name": self.config.bucket_name
+            "bucket_name": self.upload_config.bucket_name
         })
 
         after = self.db.get_pg_record("upload_area", self.area_id)
         self.assertEqual(after["id"], self.area_id)
-        self.assertEqual(after["bucket_name"], self.config.bucket_name)
+        self.assertEqual(after["bucket_name"], self.upload_config.bucket_name)
         self.assertEqual(after["status"], "LOCKED")

--- a/tests/unit/common/test_upload_area.py
+++ b/tests/unit/common/test_upload_area.py
@@ -1,0 +1,232 @@
+import uuid
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+from moto import mock_sts
+from sqlalchemy.orm.exc import NoResultFound
+
+from .. import UploadTestCaseUsingMockAWS
+
+from upload.common.database_orm import DBSessionMaker, DbUploadArea, DbFile
+from upload.common.upload_area import UploadArea
+from upload.common.uploaded_file import UploadedFile
+from upload.common.exceptions import UploadException
+
+
+class UploadAreaTest(UploadTestCaseUsingMockAWS):
+
+    def setUp(self):
+        super().setUp()
+        self.db_session_maker = DBSessionMaker()
+        self.db = self.db_session_maker.session()
+
+    def _create_area(self, status='UNLOCKED'):
+        area_id = str(uuid.uuid4())
+        db_area = DbUploadArea(id=area_id, bucket_name=self.upload_config.bucket_name, status=status)
+        self.db.add(db_area)
+        self.db.commit()
+        return area_id
+
+
+class TestUploadAreaCreationExistenceAndDeletion(UploadAreaTest):
+
+    def test_update_or_create__when_no_area_exists__creates_db_record(self):
+        area_id = str(uuid.uuid4())
+        with self.assertRaises(NoResultFound):
+            self.db.query(DbUploadArea).filter(DbUploadArea.id == area_id).one()
+
+        UploadArea(uuid=area_id).update_or_create()
+
+        record = self.db.query(DbUploadArea).filter(DbUploadArea.id == area_id).one()
+        self.assertEqual(area_id, record.id)
+        self.assertEqual(self.upload_config.bucket_name, record.bucket_name)
+        self.assertEqual("UNLOCKED", record.status)
+
+    def test_update_or_create__when_area_exists__retrieves_db_record(self):
+        area_id = self._create_area()
+
+        area = UploadArea(uuid=area_id)
+        area.update_or_create()
+
+        self.assertEqual(area_id, area._db_record()['id'])
+
+    def test_is_extant__for_nonexistant_area__returns_false(self):
+        area_id = "an-area-that-will-not-exist"
+
+        self.assertFalse(UploadArea(area_id).is_extant())
+
+    def test_is_extant__for_deleted_area__returns_false(self):
+        area_id = self._create_area('DELETED')
+
+        self.assertFalse(UploadArea(area_id).is_extant())
+
+    def test_is_extant__for_existing_area__returns_true(self):
+        area_id = self._create_area()
+
+        self.assertTrue(UploadArea(area_id).is_extant())
+        pass
+
+    def test_delete__marks_area_delete_and_deletes_objects(self):
+        area_id = self._create_area()
+        obj = self.upload_bucket.Object(f'{area_id}/test_file')
+        obj.put(Body="foo")
+
+        with patch('upload.common.upload_area.UploadArea._retrieve_upload_area_deletion_lambda_timeout') as mock_retr:
+            mock_retr.return_value = 900
+
+            area = UploadArea(uuid=area_id)
+            area.delete()
+
+        db_area = self.db.query(DbUploadArea).get(area_id)
+        self.assertEqual("DELETED", db_area.status)
+        with self.assertRaises(ClientError):
+            obj.load()
+
+
+class TestUploadAreaCredentials(UploadAreaTest):
+
+    @mock_sts
+    def test_with_deleted_upload_area__raises(self):
+        area_id = self._create_area('DELETED')
+
+        with self.assertRaises(UploadException):
+            area = UploadArea(area_id)
+            area.credentials()
+
+    @mock_sts
+    def test_with_existing_locked_upload_area__raises(self):
+        area_id = self._create_area()
+        area = UploadArea(area_id)
+        area.lock()
+
+        with self.assertRaises(UploadException):
+            area.credentials()
+
+    @mock_sts
+    def test_with_existing_unlocked_upload_area__returns_creds(self):
+        area_id = self._create_area()
+
+        area = UploadArea(area_id)
+        creds = area.credentials()
+
+        keys = list(creds.keys())
+        keys.sort()
+        self.assertEqual(['AccessKeyId', 'Expiration', 'SecretAccessKey', 'SessionToken'], keys)
+
+
+class TestUploadAreaLocking(UploadAreaTest):
+
+    def setUp(self):
+        super().setUp()
+        area_id = self._create_area()
+        self.area = UploadArea(uuid=area_id)
+        self.db_area = self.db.query(DbUploadArea).get(area_id)
+
+    def test_lock__with_unlocked_area__locks_area(self):
+        self.assertEqual("UNLOCKED", self.db_area.status)
+
+        self.area.lock()
+
+        self.db.refresh(self.db_area)
+        self.assertEqual("LOCKED", self.db_area.status)
+
+    def test_unlock__with_locked_area__unlocks_area(self):
+        self.db_area.status = 'LOCKED'
+        self.db.add(self.db_area)
+        self.db.commit()
+
+        self.area.unlock()
+
+        self.db.refresh(self.db_area)
+        self.assertEqual("UNLOCKED", self.db_area.status)
+
+
+class TestUploadAreaFileManipulation(UploadAreaTest):
+
+    def test_store_file(self):
+        area_id = self._create_area()
+        area = UploadArea(uuid=area_id)
+
+        filename = "some.json"
+        content_type = 'application/json; dcp-type="metadata/sample"'
+        content = "exquisite corpse"
+        fileinfo = area.store_file(filename, content=content, content_type=content_type)
+
+        s3_key = f"{area_id}/some.json"
+        o1 = self.upload_bucket.Object(s3_key)
+        o1.load()
+        self.assertEqual({
+            'upload_area_id': area_id,
+            'name': 'some.json',
+            'size': 16,
+            'last_modified': o1.last_modified.isoformat(),
+            'content_type': 'application/json; dcp-type="metadata/sample"',
+            'url': f"s3://{self.upload_config.bucket_name}/{area_id}/some.json",
+            'checksums': {
+                "crc32c": "FE9ADA52",
+                "s3_etag": "18f17fbfdd21cf869d664731e10d4ffd",
+                "sha1": "b1b101e21cf9cf8a4729da44d7818f935eec0ce8",
+                "sha256": "29f5572dfbe07e1db9422a4c84e3f9e455aab9ac596f0bf3340be17841f26f70"
+            }
+        }, fileinfo)
+        obj = self.upload_bucket.Object(f"{area_id}/some.json")
+        self.assertEqual("exquisite corpse".encode('utf8'), obj.get()['Body'].read())
+
+        file_id = f"{area.uuid}/{filename}"
+        db_file = self.db.query(DbFile).get(file_id)
+        self.assertEqual(16, db_file.size)
+        self.assertEqual(area_id, db_file.upload_area_id)
+        self.assertEqual("some.json", db_file.name)
+
+    def test_ls__returns_info_on_all_files_in_upload_area(self):
+        area_id = self._create_area()
+        o1 = self.mock_upload_file(area_id, 'file1.json', content_type='application/json; dcp-type="metadata/foo"')
+        o2 = self.mock_upload_file(area_id, 'file2.fastq.gz',
+                                   content_type='application/octet-stream; dcp-type=data',
+                                   checksums={'s3_etag': 'a', 'sha1': 'b', 'sha256': 'c', 'crc32c': 'd'})
+
+        area = UploadArea(uuid=area_id)
+        data = area.ls()
+
+        self.assertIn('size', data['files'][0].keys())  # moto file sizes are not accurate
+        for fileinfo in data['files']:
+            del fileinfo['size']
+        self.assertEqual(data['files'][0], {
+            'upload_area_id': area_id,
+            'name': 'file1.json',
+            'last_modified': o1.last_modified.isoformat(),
+            'content_type': 'application/json; dcp-type="metadata/foo"',
+            'url': f"s3://{self.upload_config.bucket_name}/{area_id}/file1.json",
+            'checksums': {'s3_etag': '1', 'sha1': '2', 'sha256': '3', 'crc32c': '4'}
+        })
+        self.assertEqual(data['files'][1], {
+            'upload_area_id': area_id,
+            'name': 'file2.fastq.gz',
+            'last_modified': o2.last_modified.isoformat(),
+            'content_type': 'application/octet-stream; dcp-type=data',
+            'url': f"s3://{self.upload_config.bucket_name}/{area_id}/file2.fastq.gz",
+            'checksums': {'s3_etag': 'a', 'sha1': 'b', 'sha256': 'c', 'crc32c': 'd'}
+        })
+
+    def test_ls__only_lists_files_in_this_upload_area(self):
+        area1_id = self._create_area()
+        area2_id = self._create_area()
+        area_1_files = ['file1', 'file2']
+        area_2_files = ['file3', 'file4']
+        [self.mock_upload_file(area1_id, file) for file in area_1_files]
+        [self.mock_upload_file(area2_id, file) for file in area_2_files]
+
+        data = UploadArea(uuid=area2_id).ls()
+
+        self.assertEqual(area_2_files, [file['name'] for file in data['files']])
+
+    def test_uploaded_file(self):
+        area_id = self._create_area()
+        filename = "somefile.json"
+        content = "sdfewrwer"
+        self.mock_upload_file(area_id, filename=filename, contents=content)
+
+        file = UploadArea(uuid=area_id).uploaded_file(filename)
+
+        self.assertIs(UploadedFile, file.__class__)
+        self.assertEqual(filename, file.name)

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -142,8 +142,9 @@ class UploadArea:
                                                 MessageBody=json.dumps(payload))
         status = response['ResponseMetadata']['HTTPStatusCode']
         if status != 200:
-            raise UploadException(f"Adding file upload message for {self.key_prefix}{filename} \
-                                    was unsuccessful to sqs {self.config.csum_upload_q_url} )")
+            raise UploadException(status=500, title="Internal error",
+                                  detail=f"Adding file upload message for {self.key_prefix}{filename} "
+                                         f"was unsuccessful to SQS {self.config.csum_upload_q_url} )")
 
     @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
     def add_upload_area_to_delete_sqs(self):
@@ -156,8 +157,9 @@ class UploadArea:
                                                 MessageBody=json.dumps(payload))
         status = response['ResponseMetadata']['HTTPStatusCode']
         if status != 200:
-            raise UploadException(f"Adding delete message for area {self.uuid} \
-                                    was unsuccessful to sqs {self.config.area_deletion_q_url} )")
+            raise UploadException(status=500, title="Internal error",
+                                  detail=f"Adding delete message for area {self.uuid} \
+                                        was unsuccessful to sqs {self.config.area_deletion_q_url} )")
         logger.info(f"added deletion of area {self.uuid} to sqs")
 
     def store_file(self, filename, content, content_type):

--- a/uploadctl/cleanup/__init__.py
+++ b/uploadctl/cleanup/__init__.py
@@ -11,23 +11,11 @@ class CleanupCLI:
         cleanup_parser = subparsers.add_parser('cleanup', description="Clean Things Up")
         cleanup_subparsers = cleanup_parser.add_subparsers()
 
-        cleanup_areas_parser = cleanup_subparsers.add_parser('areas')
-        cleanup_areas_parser.set_defaults(command='cleanup', cleanup_command='areas')
-        cleanup_areas_parser.add_argument('--age-days', type=int, default=3, help="delete areas older than this")
-        cleanup_areas_parser.add_argument('--ignore-file-age', action='store_true', help="ignore age of files in bucket")
-        cleanup_areas_parser.add_argument('--dry-run', action='store_true', help="examine but don't take action")
-
-        cleanup_jobdefs_parser = cleanup_subparsers.add_parser('jobdefs')
-        cleanup_jobdefs_parser.set_defaults(command='cleanup', cleanup_command='jobdefs')
+        cleanup_files_parser = cleanup_subparsers.add_parser('files')
+        cleanup_files_parser.set_defaults(command='cleanup', cleanup_command='files')
+        cleanup_files_parser.add_argument('-j', '--jobs', nargs='?', help="parallelize", type=int, default=1)
 
     @classmethod
     def run(cls, args):
-        if args.cleanup_command == 'areas':
-            UploadCleaner(os.environ['DEPLOYMENT_STAGE'],
-                          clean_older_than_days=args.age_days,
-                          ignore_file_age=args.ignore_file_age,
-                          dry_run=args.dry_run)
-
-        elif args.cleanup_command == 'jobdefs':
-            ndeleted = JobDefinition.clear_all()
-            print(f"{ndeleted} Job Definitions deleted")
+        if args.cleanup_command == 'files':
+            UploadCleaner(options=args).clean_files()

--- a/uploadctl/cli.py
+++ b/uploadctl/cli.py
@@ -10,7 +10,7 @@ Upload Service Administration Tool
 import argparse
 import os
 
-# from .cleanup import CleanupCLI
+from .cleanup import CleanupCLI
 from .diagnostics import DiagnosticsCLI
 from .runlevel import RunLevelCLI
 from .test import TestCLI
@@ -39,8 +39,8 @@ class UploadctlCLI:
         elif args.command == 'test':
             TestCLI.run(args)
 
-        # elif args.command == 'cleanup':
-        #     CleanupCLI.run(args)
+        elif args.command == 'cleanup':
+            CleanupCLI.run(args)
 
         exit(0)
 
@@ -48,24 +48,24 @@ class UploadctlCLI:
     def _setup_argparse():
         parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
         parser.add_argument('-d', '--deployment',
-                            choices=['predev', 'dev', 'integration', 'staging', 'prod'],
+                            choices=['local', 'predev', 'dev', 'integration', 'staging', 'prod'],
                             help="operate on this deployment")
         subparsers = parser.add_subparsers()
 
         RunLevelCLI.configure(subparsers)
-        # CleanupCLI.configure(subparsers)
+        CleanupCLI.configure(subparsers)
         DiagnosticsCLI.configure(subparsers)
         TestCLI.configure(subparsers)
         return parser
 
     @staticmethod
     def _check_deployment(args):
-        if not args.deployment:
+        if args.deployment:
+            deployment = args.deployment
+            os.environ['DEPLOYMENT_STAGE'] = deployment
+        else:
             deployment = os.environ['DEPLOYMENT_STAGE']
             answer = input(f"Use deployment {deployment}? (y/n): ")
             if answer is not 'y':
                 exit(1)
-        else:
-            deployment = args.deployment
-            os.environ['DEPLOYMENT_STAGE'] = deployment
         return deployment

--- a/uploadctl/test/batch.py
+++ b/uploadctl/test/batch.py
@@ -21,8 +21,6 @@ class TestBatch:
 
         job_queue_arn = f"arn:aws:batch:us-east-1:{account_id}:job-queue/{self.queue_name}"
         job_role_arn = f"arn:aws:iam::{account_id}:role/{self.role_name}"
-        print(f"SAM: role_name={self.role_name}")
-        print(f"SAM: job_role_arn={job_role_arn}")
 
         job_defn = JobDefinition(
             docker_image=docker_image,


### PR DESCRIPTION
New command: `uploadctl cleanup` removes DB records for which there are no S3 objects.
Cleanup method order in `UploadedFile`
Test cleanup: create a separate test for `UploadArea`
Cleanup usage of `UploadConfig` in `UploadArea`
Fix `UploadException` usage
