### PR TITLE
 db: make file.s3_etag NOT NULL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,14 @@ db/connect:
 	psql --dbname $(DATABASE_URI)
 
 db/download:
-	$(eval DATABASE_URI = $(shell aws secretsmanager get-secret-value --secret-id dcp/upload/${DEPLOYMENT_STAGE}/database --region us-east-1 | jq -r '.SecretString | fromjson.database_uri'))
-	$(eval OUTFILE = $(shell date +upload_${DEPLOYMENT_STAGE}-%Y%m%d%H%M.sqlc))
+	# Usage: make db/download FROM=dev    - downloads DB to upload_dev-<date>.sqlc
+	$(eval DATABASE_URI = $(shell aws secretsmanager get-secret-value --secret-id dcp/upload/${FROM}/database --region us-east-1 | jq -r '.SecretString | fromjson.database_uri'))
+	$(eval OUTFILE = $(shell date +upload_${FROM}-%Y%m%d%H%M.sqlc))
 	pg_dump -Fc --dbname=$(DATABASE_URI) --file=$(OUTFILE)
 
 db/import:
-	# Usage: DEPLOYMENT_STAGE=dev make db/import     - imports upload_dev.sqlc into upload_local
-	pg_restore --clean --no-owner --dbname upload_local upload_$(DEPLOYMENT_STAGE).sqlc
+	# Usage: make db/import FROM=dev    - imports upload_dev.sqlc into upload_local
+	pg_restore --clean --no-owner --dbname upload_local upload_$(FROM).sqlc
 
 db/import/schema:
 	# Usage: DEPLOYMENT_STAGE=dev make db/import/schema  - imports upload_dev.sqlc into upload_local
@@ -59,4 +60,4 @@ db/test_migration:
 	$(MAKE) db/migrate
 	$(MAKE) db/rollback
 	$(MAKE) db/dump_schema > /tmp/after
-	diff /tmp/{before,after}
+	diff /tmp/{before,after} # No news is good news.

--- a/database/versions/217fe1d22e4e_file_s3_etag_not_null.py
+++ b/database/versions/217fe1d22e4e_file_s3_etag_not_null.py
@@ -1,0 +1,24 @@
+"""file_s3_etag_not_null
+
+Revision ID: 217fe1d22e4e
+Revises: 5ea5c9b56a3d
+Create Date: 2019-01-08 10:02:43.497731
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '217fe1d22e4e'
+down_revision = '5ea5c9b56a3d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE file ALTER COLUMN s3_etag SET NOT NULL;")
+
+
+def downgrade():
+    op.execute("ALTER TABLE file ALTER COLUMN s3_etag DROP NOT NULL;")

--- a/upload/common/checksum.py
+++ b/upload/common/checksum.py
@@ -48,8 +48,7 @@ class UploadedFileChecksummer:
             checksums = sink.get_checksums()
             if len(self.CHECKSUM_NAMES) != len(checksums):
                 error = f"checksums {checksums} for {self.uploaded_file.s3obj.key} do not meet requirements"
-                raise UploadException(status=500,
-                                      details=error)
+                raise UploadException(status=500, title=error, detail=str(checksums))
             return checksums
 
     def _compute_checksums_progress_callback(self, bytes_transferred):


### PR DESCRIPTION
Commit b56b902c "Record s3_etag in File DB records" has been propagated all the way to production.
`uploadctl cleanup files` has been run in all environments to back-populate all rows with an s3_etag.
There are now no rows with a NULL s3_etag so we can now make that column NOT NULL.