### PR TITLE
Reraise original errors where tenacity retries are used instead of throwing a tenacity retry error

### DIFF
--- a/tests/unit/docker_images/test_validator_harness.py
+++ b/tests/unit/docker_images/test_validator_harness.py
@@ -1,14 +1,14 @@
 import json
 import os
 from tempfile import TemporaryDirectory
-from mock import patch
 
 import responses
 import tenacity
+from mock import patch
 
-from .. import UploadTestCaseUsingMockAWS, EnvironmentSetup
-
+from upload.common.exceptions import UploadException
 from upload.docker_images.validator.validator_harness import ValidatorHarness
+from .. import UploadTestCaseUsingMockAWS, EnvironmentSetup
 
 
 class TestValidatorHarness(UploadTestCaseUsingMockAWS):
@@ -96,7 +96,7 @@ class TestValidatorHarness(UploadTestCaseUsingMockAWS):
             self.expected_file_path = f"{staging_dir}/{self.upload_area_id}/{self.filename}"
             self.mock_download_file_call_count = 0
 
-            with self.assertRaises(tenacity.RetryError):
+            with self.assertRaises(UploadException):
                 harness._stage_files_to_be_validated()
 
             self.assertEqual(5, self.mock_download_file_call_count)
@@ -116,7 +116,6 @@ class TestValidatorHarness(UploadTestCaseUsingMockAWS):
 
     def test__run_validator__runs_binary_and_returns_results_dict_for_validator_running_successfully(self):
         with TemporaryDirectory() as staging_dir:
-
             harness = ValidatorHarness(path_to_validator='/usr/bin/sum',
                                        s3_urls_of_files_to_be_validated=[self.s3_url],
                                        staging_folder=staging_dir)
@@ -144,7 +143,6 @@ class TestValidatorHarness(UploadTestCaseUsingMockAWS):
         s3_url = f"s3://{self.upload_config.bucket_name}/{self.upload_area_id}/{filename}"
 
         with TemporaryDirectory() as staging_dir:
-
             harness = ValidatorHarness(path_to_validator='/usr/bin/sum',
                                        s3_urls_of_files_to_be_validated=[s3_url],
                                        staging_folder=staging_dir)
@@ -176,7 +174,6 @@ class TestValidatorHarness(UploadTestCaseUsingMockAWS):
                       status=204)
 
         with TemporaryDirectory() as staging_dir:
-
             harness = ValidatorHarness(path_to_validator='/usr/bin/sum',
                                        s3_urls_of_files_to_be_validated=[self.s3_url],
                                        staging_folder=staging_dir)

--- a/upload/common/dss_checksums.py
+++ b/upload/common/dss_checksums.py
@@ -100,7 +100,7 @@ class DssChecksums(collections.abc.MutableMapping):
                 tags_dict = self._decode_s3_tagset(tagging['TagSet'])
             return tags_dict
 
-        @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
+        @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(5))
         def save_tags(self, checksums):
             tags = {f"{DssChecksums.TAG_PREFIX}{csum_name}": csum for csum_name, csum in checksums.items()}
 

--- a/upload/common/ingest_notifier.py
+++ b/upload/common/ingest_notifier.py
@@ -49,7 +49,7 @@ class IngestNotifier:
             self._create_or_update_db_notification(notification_id, "DELIVERED", payload)
         return notification_id
 
-    @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(3))
     def _send_notification(self, notification_id, payload):
         try:
             logger.info(f"attempting notification_id:{notification_id}, payload:{payload}, \

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -148,7 +148,7 @@ class UploadArea:
     def s3_object_for_file(self, filename):
         return self._bucket.Object(self.key_prefix + filename)
 
-    @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(5))
     def add_uploaded_file_to_csum_daemon_sqs(self, filename):
         payload = {
             'Records': [{
@@ -171,7 +171,7 @@ class UploadArea:
                                   detail=f"Adding file upload message for {self.key_prefix}{filename} "
                                          f"was unsuccessful to SQS {self.config.csum_upload_q_url} )")
 
-    @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(5))
     def add_upload_area_to_delete_sqs(self):
         self.status = "DELETION_QUEUED"
         self._db_update()

--- a/upload/common/validation_scheduler.py
+++ b/upload/common/validation_scheduler.py
@@ -62,7 +62,7 @@ class ValidationScheduler:
             files_size += file.size
         return files_size < MAX_FILE_SIZE_IN_BYTES
 
-    @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(5))
     def add_to_validation_sqs(self, filenames: list, validator_image: str, env: dict, orig_val_id=None):
         validation_id = str(uuid.uuid4())
         payload = {

--- a/upload/docker_images/validator/validator_harness.py
+++ b/upload/docker_images/validator/validator_harness.py
@@ -10,6 +10,8 @@ import boto3
 from urllib3.util import parse_url
 from tenacity import retry, stop_after_attempt, before_log, before_sleep_log, wait_exponential, TryAgain
 
+from upload.common.exceptions import UploadException
+from upload.common.upload_api_client import update_event
 from upload.common.validation_event import ValidationEvent
 from upload.common.logging import get_logger
 from upload.common.upload_api_client import update_event
@@ -83,6 +85,10 @@ class ValidatorHarness:
                                                                           file_path=staged_file_path))
             staged_file_path.parent.mkdir(parents=True, exist_ok=True)
             self._download_file_from_bucket_to_filesystem(s3_bucket_name, s3_object_key, staged_file_path)
+            if not staged_file_path.is_file():
+                raise UploadException(status=500, title="Staged file path is not a file",
+                                      detail=f"Attempting to stage file path {staged_file_path} failed because it is "
+                                      f"not a file.")
             if not staged_file_path.is_file():
                 raise TryAgain
             self.staged_file_paths.append(staged_file_path)

--- a/upload/docker_images/validator/validator_harness.py
+++ b/upload/docker_images/validator/validator_harness.py
@@ -7,7 +7,7 @@ import time
 import urllib.parse
 
 import boto3
-from tenacity import retry, stop_after_attempt, before_log, before_sleep_log, wait_exponential, TryAgain
+from tenacity import retry, stop_after_attempt, before_log, before_sleep_log, wait_exponential
 from urllib3.util import parse_url
 
 from upload.common.exceptions import UploadException
@@ -86,8 +86,6 @@ class ValidatorHarness:
                 raise UploadException(status=500, title="Staged file path is not a file",
                                       detail=f"Attempting to stage file path {staged_file_path} failed because it is "
                                       f"not a file.")
-            if not staged_file_path.is_file():
-                raise TryAgain
             self.staged_file_paths.append(staged_file_path)
         return upload_area_id, file_names
 

--- a/upload/docker_images/validator/validator_harness.py
+++ b/upload/docker_images/validator/validator_harness.py
@@ -1,27 +1,24 @@
+import logging
 import os
-import sys
 import pathlib
 import subprocess
+import sys
 import time
 import urllib.parse
-import logging
 
 import boto3
-from urllib3.util import parse_url
 from tenacity import retry, stop_after_attempt, before_log, before_sleep_log, wait_exponential, TryAgain
+from urllib3.util import parse_url
 
 from upload.common.exceptions import UploadException
-from upload.common.upload_api_client import update_event
-from upload.common.validation_event import ValidationEvent
 from upload.common.logging import get_logger
 from upload.common.upload_api_client import update_event
-
+from upload.common.validation_event import ValidationEvent
 
 logger = get_logger(f"CHECKSUMMER [{os.environ.get('AWS_BATCH_JOB_ID')}]")
 
 
 class ValidatorHarness:
-
     DEFAULT_STAGING_AREA = "/data"
     TIMEOUT = None
 
@@ -35,10 +32,10 @@ class ValidatorHarness:
         self.validation_id = os.environ['VALIDATION_ID']
         self._log("VALIDATOR STARTING version={version}, job_id={job_id}, "
                   "validation_id={validation_id} attempt={attempt}".format(
-                      version=self.version,
-                      job_id=self.job_id,
-                      validation_id=self.validation_id,
-                      attempt=os.environ['AWS_BATCH_JOB_ATTEMPT']))
+            version=self.version,
+            job_id=self.job_id,
+            validation_id=self.validation_id,
+            attempt=os.environ['AWS_BATCH_JOB_ATTEMPT']))
 
     def validate(self, test_only=False):
         self._log("VERSION {version}, attempt {attempt} with argv: {argv}".format(

--- a/upload/docker_images/validator/validator_harness.py
+++ b/upload/docker_images/validator/validator_harness.py
@@ -32,10 +32,10 @@ class ValidatorHarness:
         self.validation_id = os.environ['VALIDATION_ID']
         self._log("VALIDATOR STARTING version={version}, job_id={job_id}, "
                   "validation_id={validation_id} attempt={attempt}".format(
-            version=self.version,
-            job_id=self.job_id,
-            validation_id=self.validation_id,
-            attempt=os.environ['AWS_BATCH_JOB_ATTEMPT']))
+                      version=self.version,
+                      job_id=self.job_id,
+                      validation_id=self.validation_id,
+                      attempt=os.environ['AWS_BATCH_JOB_ATTEMPT']))
 
     def validate(self, test_only=False):
         self._log("VERSION {version}, attempt {attempt} with argv: {argv}".format(

--- a/upload/docker_images/validator/validator_harness.py
+++ b/upload/docker_images/validator/validator_harness.py
@@ -61,7 +61,8 @@ class ValidatorHarness:
 
         self._unstage_files()
 
-    @retry(stop=stop_after_attempt(5),
+    @retry(reraise=True,
+           stop=stop_after_attempt(5),
            wait=wait_exponential(multiplier=10, min=1, max=4),
            before=before_log(logger, logging.DEBUG),
            before_sleep=before_sleep_log(logger, logging.ERROR))


### PR DESCRIPTION
In all Tenacity retries, updating the signature so that the original error is thrown using the flag reraise=True instead of throwing a RetryError which essentially swallows the original error. Updated the necessary tests.