### PR TITLE
use write/read for s3 consistency on s3 put and add functional test for put_file via api

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -126,3 +126,12 @@ FixtureFile.register(name='10241MB_file',
                          "sha256": "f9212050708ba0513663538eb98dc2a4687d63821d3956f07fb6db0a4d061027",
                          "crc32c": "68AF9466"
                      })
+
+FixtureFile.register(name='metadata_file.json',
+                     contents={'test_obj': 'test_obj'},
+                     checksums={
+                         "s3_etag": "98b3a7471805e97a493c0e42763abe14",
+                         "sha1": "f3c6f383698e3abf90721e9705d99d065708d405",
+                         "sha256": "e08097457644aef76b6129423d5f3fcbd800d39d207dbf8491db534c1d93968f",
+                         "crc32c": "EA784DAF"
+                     })

--- a/tests/functional/test_upload_service.py
+++ b/tests/functional/test_upload_service.py
@@ -35,6 +35,22 @@ class TestUploadService(unittest.TestCase):
         _end_time = time.time()
         print(f"Total startup time: {_end_time - _start_time} seconds.")
 
+    def test__put_file__successful(self):
+        # Test variables
+        _start_time = time.time()
+        _metadata_file = FixtureFile.factory('metadata_file.json')
+
+        # Run test
+        print(f"\n\nUsing environment {self.deployment_stage} at URL {self.api_url}.\n")
+        self._execute_create_upload_area()
+        self._execute_put_file_using_api(_metadata_file)
+        self._verify_file_was_checksummed_inline(_metadata_file)
+
+        self._execute_delete_upload_area()
+
+        _end_time = time.time()
+        print(f"Total test_upload__small_file__successful time: {_end_time - _start_time} seconds.")
+
     def test__upload_small_file__successful(self):
         # Test variables
         _start_time = time.time()
@@ -113,6 +129,16 @@ class TestUploadService(unittest.TestCase):
     def _execute_upload_file_using_cli(self, file_location):
         self._run_cli_command("SELECT UPLOAD AREA", ['hca', 'upload', 'select', self.uri])
         self._run_cli_command("UPLOAD FILE USING CLI", ['hca', 'upload', 'files', file_location])
+
+    def _execute_put_file_using_api(self, test_file):
+        headers = {'Content-Type': 'application/json; dcp-type=data'}
+        headers.update(self.auth_headers)
+        self._make_request(description="VALIDATE",
+                           verb='PUT',
+                           url=f"{self.api_url}/area/{self.upload_area_uuid}/{test_file.name}",
+                           expected_status=201,
+                           headers=headers,
+                           json=test_file.contents)
 
     def _execute_validate_file(self, test_file):
         response = self._make_request(description="VALIDATE",

--- a/upload/common/uploaded_file.py
+++ b/upload/common/uploaded_file.py
@@ -11,7 +11,7 @@ if not os.environ.get("CONTAINER"):
     from .database import UploadDB
 
 s3 = boto3.resource('s3')
-s3client = boto3.client('s3')
+s3_client = boto3.client('s3')
 
 
 class UploadedFile:
@@ -22,9 +22,10 @@ class UploadedFile:
 
     @classmethod
     def create(cls, upload_area, name=None, content_type=None, data=None):
-        s3object = upload_area.s3_object_for_file(name)
-        s3object.put(Body=data, ContentType=content_type)
-        return cls(upload_area, s3object=s3object)
+        obj_key = f"{upload_area.uuid}/{name}"
+        s3_client.put_object(Body=data, ContentType=content_type, Bucket=upload_area.bucket_name, Key=obj_key)
+        s3_object = upload_area.s3_object_for_file(name)
+        return cls(upload_area, s3object=s3_object)
 
     @classmethod
     def from_s3_key(cls, upload_area, s3_key):


### PR DESCRIPTION
This is related to #304. This follows https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel via using write than read in order to avoid eventual consistency issues. This PR also adds in a functional test for put_file via the api.