### PR TITLE
use dynamic maintenance window for rds

### DIFF
--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -47,6 +47,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 
   // DCP Ingest
   ingest_api_host = "${var.ingest_api_host}"

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -27,6 +27,7 @@ csum_cluster_min_vcpus = 0
 db_username = "xxxxxxxx"
 db_password = "xxxxxxxxxxxxx"
 db_instance_count = 1
+preferred_maintenance_window = "sat:09:08-sat:09:38"
 
 // DCP Ingest
 ingest_api_host = "api.ingest.<deployment_stage>.data.humancellatlas.org"

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -67,6 +67,9 @@ variable "db_password" {
 variable "db_instance_count" {
   type = "string"
 }
+variable "preferred_maintenance_window" {
+  type = "string"
+}
 
 // DCP Ingest
 

--- a/terraform/envs/integration/main.tf
+++ b/terraform/envs/integration/main.tf
@@ -47,6 +47,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 
   // DCP Ingest
   ingest_api_host = "${var.ingest_api_host}"

--- a/terraform/envs/parth/main.tf
+++ b/terraform/envs/parth/main.tf
@@ -47,6 +47,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 
   // DCP Ingest
   ingest_api_host = "${var.ingest_api_host}"

--- a/terraform/envs/predev/main.tf
+++ b/terraform/envs/predev/main.tf
@@ -47,6 +47,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 
   // DCP Ingest
   ingest_api_host = "${var.ingest_api_host}"

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -47,6 +47,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 
   // DCP Ingest
   ingest_api_host = "${var.ingest_api_host}"

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -47,6 +47,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 
   // DCP Ingest
   ingest_api_host = "${var.ingest_api_host}"

--- a/terraform/envs/testing/main.tf
+++ b/terraform/envs/testing/main.tf
@@ -51,6 +51,7 @@ module "upload-service" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 
   // DCP Ingest
   ingest_amqp_server = "${var.ingest_amqp_server}"

--- a/terraform/modules/database/database.tf
+++ b/terraform/modules/database/database.tf
@@ -8,7 +8,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   engine_version          = "9.6.8"
   auto_minor_version_upgrade = "true"
   performance_insights_enabled = "true"
-  preferred_maintenance_window = "sat:09:08-sat:09:38"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 }
 
 resource "aws_rds_cluster" "upload" {
@@ -23,7 +23,7 @@ resource "aws_rds_cluster" "upload" {
   backup_retention_period = 7
   port                    = 5432
   preferred_backup_window = "07:27-07:57"
-  preferred_maintenance_window = "sat:09:08-sat:09:38"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
   storage_encrypted       = "true"
   skip_final_snapshot     = "true"
   vpc_security_group_ids  = ["${aws_security_group.rds-postgres.id}"]

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -26,3 +26,7 @@ variable "db_instance_count" {
   type = "string"
   default = 2
 }
+
+variable "preferred_maintenance_window" {
+  type = "string"
+}

--- a/terraform/modules/upload-service/main.tf
+++ b/terraform/modules/upload-service/main.tf
@@ -20,4 +20,5 @@ module "upload-service-database" {
   pgbouncer_subnet_id = "${element(data.aws_subnet_ids.upload_vpc.ids, 0)}"
   lb_subnet_ids = "${data.aws_subnet_ids.upload_vpc.ids}"
   vpc_id = "${module.upload-vpc.vpc_id}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
 }

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -70,6 +70,9 @@ variable "db_instance_count" {
   type = "string"
   default = 2
 }
+variable "preferred_maintenance_window" {
+  type = "string"
+}
 
 # DCP Ingest
 


### PR DESCRIPTION
Values set for current environment in updated tfvars files:
Dev: "sat:09:08-sat:09:38"
Integration: "sat:09:08-sat:09:38"
Staging : "wed:15:00-sat:15:30" (8-8:30am EST for deployments)
Prod: "tue:15:00-sat:15:30" (8-8:30am EST for deployments)