### PR TITLE
Fix test interaction problems

### DIFF
--- a/tests/unit/common/test_uploaded_file.py
+++ b/tests/unit/common/test_uploaded_file.py
@@ -1,4 +1,5 @@
 import os
+import random
 import uuid
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -7,7 +8,6 @@ from .. import UploadTestCaseUsingMockAWS
 from ... import FixtureFile
 
 from upload.common.database_orm import DBSessionMaker, DbFile
-from upload.common.dss_checksums import DssChecksums
 from upload.common.upload_area import UploadArea
 from upload.common.uploaded_file import UploadedFile
 
@@ -39,7 +39,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         pass
 
     def test_create__creates_a_new_s3_object_and_db_record(self):
-        filename = "file1"
+        filename = f"file-{random.randint(0,999999999)}"
         content_type = "application/octet-stream; dcp-type=data"
         file_content = "file1_content"
 
@@ -64,7 +64,8 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(self.upload_area.db_id, record.upload_area_id)
 
     def test_init__given_existing_entities__initializes_properties_correctly(self):
-        s3object = self.create_s3_object(f"{self.upload_area_id}/foo")
+        filename = f"file-{random.randint(0,999999999)}"
+        s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
         file_record = self.create_file_record(s3object)
 
         uf = UploadedFile(self.upload_area, s3object=s3object)
@@ -81,7 +82,8 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(s3object.content_length, uf.size)
 
     def test_init__when_no_db_record_exists__creates_a_db_record(self):
-        s3object = self.create_s3_object(f"{self.upload_area_id}/foo")
+        filename = f"file-{random.randint(0,999999999)}"
+        s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
 
         with self.assertRaises(NoResultFound):
             self.db.query(DbFile).filter(DbFile.s3_key == s3object.key,
@@ -93,23 +95,26 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
                                               DbFile.s3_etag == s3object.e_tag.strip('\"')).one()
         self.assertEqual(record.id, uf.db_id)
         self.assertEqual(s3object.key, record.s3_key)
-        self.assertEqual("foo", record.name)
+        self.assertEqual(filename, record.name)
         self.assertEqual(s3object.e_tag.strip('\"'), record.s3_etag)
         self.assertEqual(s3object.content_length, record.size)
         self.assertEqual(self.upload_area.db_id, record.upload_area_id)
 
     def test_init__doesnt_create_db_record_if_one_already_exists(self):
-        s3object = self.create_s3_object(f"{self.upload_area_id}/foo")
+        filename = f"file-{random.randint(0,999999999)}"
+        s3_key = f"{self.upload_area_id}/{filename}"
+        s3object = self.create_s3_object(s3_key)
         self.create_file_record(s3object)
-
-        record_count_before = self.db.query(DbFile).count()
+        record_count_before = self.db.query(DbFile).filter(DbFile.s3_key == s3_key).count()
 
         UploadedFile(upload_area=self.upload_area, s3object=s3object)
 
-        self.assertEqual(record_count_before, self.db.query(DbFile).count())
+        record_count_after = self.db.query(DbFile).filter(DbFile.s3_key == s3_key).count()
+        self.assertEqual(record_count_before, record_count_after)
 
     def test_from_s3_key__initializes_correctly(self):
-        s3object = self.create_s3_object(f"{self.upload_area_id}/foo")
+        filename = f"file-{random.randint(0,999999999)}"
+        s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
         file_record = self.create_file_record(s3object)
 
         uf = UploadedFile.from_s3_key(self.upload_area, s3_key=s3object.key)
@@ -119,7 +124,8 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(file_record.id, uf.db_id)
 
     def test_from_db_id__initializes_correctly_and_figures_out_which_upload_area_to_use(self):
-        s3object = self.create_s3_object(f"{self.upload_area_id}/foo")
+        filename = f"file-{random.randint(0,999999999)}"
+        s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
         file_record = self.create_file_record(s3object)
 
         uf = UploadedFile.from_db_id(file_record.id)
@@ -130,7 +136,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(file_record.id, uf.db_id)
 
     def test_refresh__picks_up_changed_content_type(self):
-        filename = "file3"
+        filename = f"file-{random.randint(0,999999999)}"
         old_content_type = "application/octet-stream"  # missing dcp-type
         new_content_type = "application/octet-stream; dcp-type=data"
         s3object = self.create_s3_object(object_key=f"{self.upload_area.uuid}/{filename}",
@@ -149,7 +155,8 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(new_content_type, uf.content_type)
 
     def test_checksums_setter_saves_db_record(self):
-        s3object = self.create_s3_object(f"{self.upload_area_id}/foo")
+        filename = f"file-{random.randint(0,999999999)}"
+        s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
         file_record = self.create_file_record(s3object)
         uf = UploadedFile.from_db_id(file_record.id)
 

--- a/tests/unit/lambdas/test_checksum_daemon.py
+++ b/tests/unit/lambdas/test_checksum_daemon.py
@@ -156,11 +156,12 @@ class TestChecksumDaemonSeeingS3ObjectsForWhichAFileRecordAlreadyExists(Checksum
 
     @patch('upload.lambdas.checksum_daemon.checksum_daemon.IngestNotifier.format_and_send_notification')
     def test_that_a_new_file_record_is_not_created(self, mock_fasn):
-        record_count_before = self.db.query(DbFile).count()
+        record_count_before = self.db.query(DbFile).filter(DbFile.s3_key == self.file_key).count()
 
         self.daemon.consume_events(self.events)
 
-        self.assertEqual(record_count_before, self.db.query(DbFile).count())
+        record_count_after = self.db.query(DbFile).filter(DbFile.s3_key == self.file_key).count()
+        self.assertEqual(record_count_before, record_count_after)
 
     @patch('upload.lambdas.checksum_daemon.checksum_daemon.DssChecksums.compute')
     @patch('upload.lambdas.checksum_daemon.checksum_daemon.IngestNotifier.format_and_send_notification')


### PR DESCRIPTION
Because we have a shared test database, tests running simultaneously
can stomp all over each other.  Randomize filenames used in tests and
make queries filter on the filenames.