### PR TITLE
New Validation AMI, use M5 instances in Batch

### DIFF
--- a/amis/README.md
+++ b/amis/README.md
@@ -8,7 +8,8 @@ As we need to download data files to the instances booted for these batch jobs, 
 To achieve this we create a new AMI that:
 
  - Is based on Amazon's ECS Optimized AMI for our region.
- - Has an additional 1TB filesystem mounted at /data, which we will use for staging files to be validated.
+ - Has a modifed block device mapping that causes an additional 1TB volume to be attached
+ - Has an init script that formats and mounts the extra volume at /data.
 
 ## To create the AMI
 
@@ -35,19 +36,23 @@ To achieve this we create a new AMI that:
 4. AFTER the instance has booted attach another volume.  It is important to do this after boot, as otherwise the
        instance gets confused about which of the two suitable disks it has is the root filesystem.  This way it
        will definitely have the highest minor number.
-    1. Create another EBS volume from the ecosami-rootfs-snap
-    1. Attach it to the instance you booted.
-5.  Login to the system
-6.  Mount the new volume on `/mnt`.
+    1. Create another EBS volume from the ecosami-rootfs-snap:
+       AWS Console -> EC2 -> Elastic Block Store -> Create Volume -> 8GB, _ecosami-rootfs-snap_
+    1. Attach it to the instance you booted:
+       _volume_ -> _right click_ -> Attach Volume -> _your instance_ -> /dev/sdf
+5.  Copy the `dcpfs` scrip to the booted instance:
+    `cd amis ; scp dcpfs ec2-user@ec2-X-X-X-X.compute.amazonaws.com:/tmp`
+6.  Login to the system (typically as `ec2-user`)
+7.  Mount the new volume on `/mnt`:
     * Run `lsblk` to find your device.
-    * In am m4 instance it was `mount /dev/xvdg1 /mnt`
-    * In am m5 instance it was `mount /dev/nvme2n1p1 /mnt`
-7.  Copy the `dcpfs` init script to `/mnt/etc/init.d`
-    1.  Edit the script the fix the BLOCK_DEVICE
-      * In an m4 instance it was `/dev/xvdb`
-      * In an m5 instance it was `/dev/nvme1n1`
-    1.    make symlinks to the appropriate `rc?.d` folders with `chkconfig`
-          (note that I tried doing this with `chroot` without success):
+    * In an m4 instance it was `sudo mount /dev/xvdg1 /mnt`
+    * In an m5 instance it was `sudo mount /dev/nvme1n1p1 /mnt`
+8.  Copy the `dcpfs` init script to `/mnt/etc/init.d`
+    * Edit the script the fix the BLOCK_DEVICE
+    * In an m4 instance it was `/dev/xvdb`
+    * In an m5 instance it was `/dev/nvme1n1`
+9.  Make symlinks to the appropriate `rc?.d` folders with `chkconfig`
+    (note that I tried doing this with `chroot` without success):
 ```bash
 sudo -s
 cp /mnt/etc/init.d/dcpfs /etc/init.d
@@ -56,52 +61,56 @@ cd /etc/rc.d
 find . -name *dcpfs -type l | xargs tar cf - | (cd /mnt/etc/rc.d ; sudo tar xvf -)
 umount /mnt
 ```
-10. Stop the instance
-11. Create a snapshot of you new volume
-12. Register a new AMI:
-    1. Use the new snapshot as the root filesystem
-    1. Use the same block device map as the ecosami, with an additional 1 TB /dev/sdb volume
-
-Something like: `aws ec2 register-image --cli-input-json file://register-image.json` with:
-
+10. Terminate the instance
+11. Create a snapshot of you new volume:
+    Elastic Block Store -> Volumes -> _volume_ -> _right click_ -> Create Snapshot
+12. Craft a JSON register-image decription for your new AMI
+    * Start with the output of `aws ec2 register-image --generate-cli-skeleton`
+    * Copy as many values as possible from the old AMI.  You can get that info using:
+    `aws ec2 describe-images --image-ids ecosapi`
+    * Use the new snapshot you created for the root filesystem.
+    * Edit the json and add a new stanza to the block device mapping for a 1TB volume.
+      Use the next block device number, e.g. if the root fs is `/dev/xvda`, you would use `/dev/xvdb`.
+      You should end up with something like:
 ```json
 {
-  "Architecture": "x86_64",
-  "BlockDeviceMappings": [
-    {
-      "DeviceName": "/dev/xvda",
-      "Ebs": {
-        "DeleteOnTermination": true,
-        "SnapshotId": "<your snapshot ID>",
-        "VolumeSize": 8,
-        "VolumeType": "gp2"
-      }
-    },
-    {
-      "DeviceName": "/dev/xvdb",
-      "Ebs": {
-        "Encrypted": false,
-        "DeleteOnTermination": true,
-        "VolumeSize": 1096,
-        "VolumeType": "gp2"
-      }
-    },
-    {
-      "DeviceName": "/dev/xvdcz",
-      "Ebs": {
-        "Encrypted": false,
-        "DeleteOnTermination": true,
-        "VolumeSize": 22,
-        "VolumeType": "gp2"
-      }
-    }
-  ],
-  "Description": "amzn-ami-2017.09.c-amazon-ecs-optimized + 1TB sdb=/data",
-  "DryRun": false,
-  "EnaSupport": true,
-  "Name": "ecso-with-data-vol-v2",
-  "RootDeviceName": "/dev/xvda",
-  "SriovNetSupport": "simple",
-  "VirtualizationType": "hvm"
+    "Architecture": "x86_64",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "SnapshotId": "snap-xxxxxxxxxxxxxxxxx",
+                "VolumeSize": 30,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/xvdb",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 1096,
+                "VolumeType": "gp2",
+                "Encrypted": false
+            }
+        }
+    ],
+    "Description": "Amazon Linux AMI 2.0.20190301 x86_64 ECS HVM GP2 + 1TB@/data",
+    "DryRun": false,
+    "EnaSupport": true,
+    "Name": "ecos-with-data-vol-m5-v2",
+    "RootDeviceName": "/dev/xvda",
+    "SriovNetSupport": "simple",
+    "VirtualizationType": "hvm"
 }
 ```
+
+13. Register the new AMI
+
+    Something like: `aws ec2 register-image --cli-input-json file://register-image.json`
+
+14. Cleanup
+    * Delete the rootfs EBS volume, you no longer need it.
+    * Don't delete the shapshot.  The AMI needs that.
+
+15. See if Batch will use your new AMI.

--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -37,10 +37,12 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_instance_type = "${var.validation_cluster_instance_type}"
   validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_instance_type = "${var.csum_cluster_instance_type}"
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -19,12 +19,12 @@ csum_docker_image = "humancellatlas/upload-checksummer:8"
 // Validation Batch infrastructure.
 validation_cluster_ec2_key_pair = "my-ec2-keypair"
 validation_cluster_ami_id = "ami-xxxxxxxx"
-validation_cluster_instance_type = "m4"
+validation_cluster_instance_type = "m5"
 validation_cluster_min_vcpus = 0
 
 // Checksumming Batch infrastructure.
 csum_cluster_ec2_key_pair = "my-ec2-keypair"
-csum_cluster_instance_type = "m4"
+csum_cluster_instance_type = "m5"
 csum_cluster_min_vcpus = 0
 
 // Database

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -19,10 +19,12 @@ csum_docker_image = "humancellatlas/upload-checksummer:8"
 // Validation Batch infrastructure.
 validation_cluster_ec2_key_pair = "my-ec2-keypair"
 validation_cluster_ami_id = "ami-xxxxxxxx"
+validation_cluster_instance_type = "m4"
 validation_cluster_min_vcpus = 0
 
 // Checksumming Batch infrastructure.
 csum_cluster_ec2_key_pair = "my-ec2-keypair"
+csum_cluster_instance_type = "m4"
 csum_cluster_min_vcpus = 0
 
 // Database

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -46,10 +46,16 @@ variable "validation_cluster_ec2_key_pair" {
 variable "validation_cluster_ami_id" {
   type = "string"
 }
+variable "validation_cluster_instance_type" {
+  type = "string"
+}
 variable "validation_cluster_min_vcpus" {
   type = "string"
 }
 variable "csum_cluster_ec2_key_pair" {
+  type = "string"
+}
+variable "csum_cluster_instance_type" {
   type = "string"
 }
 variable "csum_cluster_min_vcpus" {

--- a/terraform/envs/integration/main.tf
+++ b/terraform/envs/integration/main.tf
@@ -37,10 +37,12 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_instance_type = "${var.validation_cluster_instance_type}"
   validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_instance_type = "${var.csum_cluster_instance_type}"
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -37,10 +37,12 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_instance_type = "${var.validation_cluster_instance_type}"
   validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_instance_type = "${var.csum_cluster_instance_type}"
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database

--- a/terraform/envs/sam/main.tf
+++ b/terraform/envs/sam/main.tf
@@ -37,10 +37,12 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_instance_type = "${var.validation_cluster_instance_type}"
   validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_instance_type = "${var.csum_cluster_instance_type}"
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -37,10 +37,12 @@ module "upload-service" {
   // Validation Batch infrastructure.
   validation_cluster_ec2_key_pair = "${var.validation_cluster_ec2_key_pair}"
   validation_cluster_ami_id = "${var.validation_cluster_ami_id}"
+  validation_cluster_instance_type = "${var.validation_cluster_instance_type}"
   validation_cluster_min_vcpus = "${var.validation_cluster_min_vcpus}"
 
   // Checksumming Batch infrastructure.
   csum_cluster_ec2_key_pair = "${var.csum_cluster_ec2_key_pair}"
+  csum_cluster_instance_type = "${var.csum_cluster_instance_type}"
   csum_cluster_min_vcpus = "${var.csum_cluster_min_vcpus}"
 
   // Database

--- a/terraform/envs/test/main.tf
+++ b/terraform/envs/test/main.tf
@@ -35,6 +35,8 @@ module "upload-service-database" {
   db_username = "${var.db_username}"
   db_password = "${var.db_password}"
   db_instance_count = "${var.db_instance_count}"
+  preferred_maintenance_window = "${var.preferred_maintenance_window}"
+
   pgbouncer_subnet_id = "${element(data.aws_subnet_ids.upload_vpc.ids, 0)}"
   lb_subnet_ids = "${data.aws_subnet_ids.upload_vpc.ids}"
   vpc_id = "${module.upload-vpc.vpc_id}"

--- a/terraform/envs/test/terraform.tfvars.example
+++ b/terraform/envs/test/terraform.tfvars.example
@@ -4,3 +4,4 @@ vpc_cidr_block = "xxx.xxx.xxx.xxx/xx"
 db_username = "xxxxxxxx"
 db_password = "xxxxxxxxxxxxxx"
 db_instance_count = 1
+preferred_maintenance_window = "sat:09:08-sat:09:38"

--- a/terraform/envs/test/variables.tf
+++ b/terraform/envs/test/variables.tf
@@ -16,3 +16,6 @@ variable "db_password" {
 variable "db_instance_count" {
   type = "string"
 }
+variable "preferred_maintenance_window" {
+  type = "string"
+}

--- a/terraform/modules/upload-service/checksumming_batch.tf
+++ b/terraform/modules/upload-service/checksumming_batch.tf
@@ -21,7 +21,7 @@ resource "aws_batch_compute_environment" "csum_compute_env" {
     // Here we use an external data source to dynamically set the desired vcpus to match current state.
     desired_vcpus = "${data.external.checksum_desired_vcpus.result.desired_vcpus}"
     instance_type = [
-      "m4"
+      "${var.csum_cluster_instance_type}"
     ]
     subnets = [
       "${data.aws_subnet_ids.upload_vpc.ids}"

--- a/terraform/modules/upload-service/validation.tf
+++ b/terraform/modules/upload-service/validation.tf
@@ -21,7 +21,7 @@ resource "aws_batch_compute_environment" "validation_compute_env" {
     // Here we use an external data source to dynamically set the desired vcpus to match current state.
     desired_vcpus = "${data.external.validation_desired_vcpus.result.desired_vcpus}"
     instance_type = [
-      "m4"
+      "${var.validation_cluster_instance_type}"
     ]
     image_id = "${var.validation_cluster_ami_id}"
     subnets = [

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -45,11 +45,17 @@ variable "validation_cluster_ec2_key_pair" {
 variable "validation_cluster_ami_id" {
   type = "string"
 }
+variable "validation_cluster_instance_type" {
+  type = "string"
+}
 variable "validation_cluster_min_vcpus" {
   type = "string"
 }
 
 variable "csum_cluster_ec2_key_pair" {
+  type = "string"
+}
+variable "csum_cluster_instance_type" {
   type = "string"
 }
 variable "csum_cluster_min_vcpus" {


### PR DESCRIPTION
I have created a new AMI for validation, `ami-0939b827b1bf145c9` a.k.a. _ecos-with-data-vol-m5-v2_.  I updated and expanded the instructions on how to create it.  This AMI is for M5 instances (instead of M4).

I've also updated the checksumming cluster to m5 at the same time.

As you deploy this code to each environment, you need to change `terraform.tfvars`:
```
        validation_cluster_ami_id = "ami-0939b827b1bf145c9"
        validation_cluster_instance_type = "m5"
    
        csum_cluster_instance_type = "m5"
```

To apply these terraform changes, you will need to delete the Batch job queues first
as Terraform seems to be dumb about the relationship between queues and clusters:

```
        tf destroy --target=module.upload-service.aws_batch_job_queue.validation_job_q
        tf destroy --target=module.upload-service.aws_batch_job_queue.csum_job_q
        make apply
```