### PR TITLE
Remove "list upload area" REST API endpoint

### DIFF
--- a/config/upload-api.yml
+++ b/config/upload-api.yml
@@ -133,40 +133,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-    get:
-      summary: List files in an upload area
-      operationId: upload.lambdas.api_server.v1.area.list_files
-      description: |
-        Provide a JSON object listing all the files in an upload area, including their checkums.
-      tags:
-        - All
-      parameters:
-        - name: upload_area_uuid
-          in: path
-          description: A RFC4122-compliant ID for the upload area.
-          required: true
-          type: string
-      responses:
-        200:
-          description: Here's your listing.
-          schema:
-            type: object
-            properties:
-              files:
-                type: array
-                items:
-                  $ref: "#/definitions/FileInfo"
-            required:
-              - files
-        404:
-          description: Could not find an upload area with that ID.
-          schema:
-            $ref: '#/definitions/Error'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-
   /v1/area/{upload_area_uuid}/credentials:
 
     post:

--- a/tests/unit/lambdas/api_server/test_area.py
+++ b/tests/unit/lambdas/api_server/test_area.py
@@ -223,16 +223,6 @@ class TestAreaApi(UploadTestCaseUsingMockAWS):
         self.assertEqual(f"s3://{self.upload_config.bucket_name}/{area_uuid}/some.json",
                          json.loads(response.data)['url'])
 
-    def test_list_files(self):
-        area_uuid = self._create_area()
-        self.mock_upload_file_to_s3(area_uuid, 'file1')
-        self.mock_upload_file_to_s3(area_uuid, 'file2')
-
-        response = self.client.get(f"/v1/area/{area_uuid}")
-
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(2, len(json.loads(response.data)['files']))
-
     def test_get_file_for_existing_file(self):
         area_uuid = self._create_area()
         filename = 'file1.json'

--- a/upload/lambdas/api_server/v1/area.py
+++ b/upload/lambdas/api_server/v1/area.py
@@ -177,12 +177,6 @@ def update_validation_event(upload_area_uuid: str, validation_id: str, body: str
 
 
 @return_exceptions_as_http_errors
-def list_files(upload_area_uuid: str):
-    upload_area = _load_upload_area(upload_area_uuid)
-    return upload_area.ls(), requests.codes.ok
-
-
-@return_exceptions_as_http_errors
 def file_info(upload_area_uuid: str, filename: str):
     upload_area = _load_upload_area(upload_area_uuid)
     uploaded_file = upload_area.uploaded_file(filename)


### PR DESCRIPTION
Removing endpoint GET /v1/area/{upload_area_uuid}.
This is and unused endpoint.
Listing files is done another way as it was discovered that this
strategy was not scalable.

Listing upload areas is done by listing the S3 bucket directly, then
calling the upload API PUT /v1/area/{upload_area_uuid}/files_info to
get the upload-specific info about the files.

**IMPORTANT: Next time we promote to Integration, PLEASE BUMP THE MAJOR VERSION NUMBER.**