### PR TITLE
Revert changes to tests. dcplib was updated so that crc32c is padded …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ botocore==1.12.119
 connexion==1.5.2
 crcmod==1.7
 cryptography==2.3.1
-dcplib==1.6.4
+dcplib==1.6.5
 jsonschema==2.6.0
 pika==0.12.0
 psycopg2-binary==2.7.5

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -101,7 +101,7 @@ FixtureFile.register(name='small_file',
                          "s3_etag": "90bb15802d139f86139a6ca72d61611b",
                          "sha1": "1039d0969f1fb147292dedfd9116fb5d447430e1",
                          "sha256": "513ede16ce2c0a32fdbe2b4177356b919bfa40523c1e5919d5ea024a53a07b7a",
-                         "crc32c": "ced75a"
+                         "crc32c": "00ced75a"
                      })
 
 FixtureFile.register(name='small_invalid_file',


### PR DESCRIPTION
…to 8 characters as it was before.