### PR TITLE
Configure API DNS record set in terraform

### DIFF
--- a/scripts/get_api_id
+++ b/scripts/get_api_id
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+usage="usage: $0 [--json] <api_gateway_name> <target_lambda_name>"
+
+JSON_FORMAT=0
+
+if [[ "$#" = 0 ]]; then
+    echo "$usage"
+    exit 1
+fi
+
+format_response() {
+    api_id="$1"
+    if [[ "$JSON_FORMAT" = 1 ]]; then
+        echo "{\"api_id\":\"$api_id\"}"
+    else
+        echo $api_id
+    fi
+}
+
+while (( "$#" )); do
+    case "$1" in
+        -j|--json)
+            eval "$(jq -r '@sh "api_gateway_name=\(.api_gateway_name) lambda_name=\(.lambda_name)"')"
+            export api_gateway_name
+            export lambda_name
+            JSON_FORMAT=1
+            shift 1
+            break
+        ;;
+    *)
+        if [[ "$#" = 2 ]]; then
+            export api_gateway_name="$1"
+            export lambda_name="$2"
+            shift 2
+        else
+            echo "$usage"
+            exit 1
+        fi
+        ;;
+    esac
+done
+
+lambda_arn=$(aws lambda list-functions | jq -r '.Functions[] | select(.FunctionName==env.lambda_name) | .FunctionArn')
+
+# Identify the id of our API Gateway by finding a gateway with a REST API with resource with an integration that
+# executes our lambda.
+for api_id in $(aws apigateway get-rest-apis | jq -r ".items[] | select(.name==\"${api_gateway_name}\") | .id") ; do
+    for resource_id in $(aws apigateway get-resources --rest-api-id $api_id | jq -r .items[].id); do
+        aws apigateway get-integration --rest-api-id $api_id --resource-id $resource_id --http-method GET >/dev/null 2>&1 || continue
+        uri=$(aws apigateway get-integration --rest-api-id $api_id --resource-id $resource_id --http-method GET | jq -r .uri)
+        if [[ $uri == *"$lambda_arn"* ]]; then
+            format_response $api_id
+            exit 0
+        fi
+    done
+done

--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -27,6 +27,9 @@ module "upload-service" {
   bucket_name_prefix = "${var.bucket_name_prefix}"
   staging_bucket_arn = "${var.staging_bucket_arn}"
 
+  // DNS
+  parent_zone_domain_name = "${var.parent_zone_domain_name}"
+
   // API Lambda
   upload_api_fqdn = "${var.upload_api_fqdn}"
   ingest_api_key = "${var.ingest_api_key}"

--- a/terraform/envs/dev/terraform.tfvars.example
+++ b/terraform/envs/dev/terraform.tfvars.example
@@ -9,8 +9,11 @@ vpc_cidr_block = "xxx.xxx.xxx.xxx/xx"
 bucket_name_prefix = "org-humancellatlas-upload-"
 staging_bucket_arn = "arn:aws:s3:::org-humancellatlas-upload-staging"
 
+// DNS
+parent_zone_domain_name = "<deployment_stage>.data.humancellatlas.org"
+
 // API Lambda
-upload_api_fqdn = "upload.<deployment_stage>.data.humancellatlas.org"
+upload_api_fqdn = "upload.<deployment_stage>.<parent_zone_domain_name>"
 ingest_api_key = "xxxxxxxxxxxxxxxxxxxx"
 
 // Checksum Lambda
@@ -34,7 +37,7 @@ db_instance_count = 1
 preferred_maintenance_window = "sat:09:08-sat:09:38"
 
 // DCP Ingest
-ingest_api_host = "api.ingest.<deployment_stage>.data.humancellatlas.org"
+ingest_api_host = "api.ingest.<deployment_stage>.<parent_zone_domain_name>"
 
 // AUTH
 dcp_auth0_audience = "https://dev.data.humancellatlas.org/"

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -23,11 +23,18 @@ variable "staging_bucket_arn" {
 }
 
 
-// API Lambda
+// DNS
+
+variable "parent_zone_domain_name" {
+  type = "string"
+}
 
 variable "upload_api_fqdn" {
   type = "string"
 }
+
+// API Lambda
+
 variable "ingest_api_key" {
   type = "string"
 }

--- a/terraform/envs/integration/main.tf
+++ b/terraform/envs/integration/main.tf
@@ -27,6 +27,9 @@ module "upload-service" {
   bucket_name_prefix = "${var.bucket_name_prefix}"
   staging_bucket_arn = "${var.staging_bucket_arn}"
 
+  // DNS
+  parent_zone_domain_name = "${var.parent_zone_domain_name}"
+
   // API Lambda
   upload_api_fqdn = "${var.upload_api_fqdn}"
   ingest_api_key = "${var.ingest_api_key}"

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -27,6 +27,9 @@ module "upload-service" {
   bucket_name_prefix = "${var.bucket_name_prefix}"
   staging_bucket_arn = "${var.staging_bucket_arn}"
 
+  // DNS
+  parent_zone_domain_name = "${var.parent_zone_domain_name}"
+
   // API Lambda
   upload_api_fqdn = "${var.upload_api_fqdn}"
   ingest_api_key = "${var.ingest_api_key}"

--- a/terraform/envs/sam/main.tf
+++ b/terraform/envs/sam/main.tf
@@ -31,6 +31,9 @@ module "upload-service" {
   upload_api_fqdn = "${var.upload_api_fqdn}"
   ingest_api_key = "${var.ingest_api_key}"
 
+  // DNS
+  parent_zone_domain_name = "${var.parent_zone_domain_name}"
+
   // Checksum Lambda
   csum_docker_image = "${var.csum_docker_image}"
 

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -27,6 +27,9 @@ module "upload-service" {
   bucket_name_prefix = "${var.bucket_name_prefix}"
   staging_bucket_arn = "${var.staging_bucket_arn}"
 
+  // DNS
+  parent_zone_domain_name = "${var.parent_zone_domain_name}"
+
   // API Lambda
   upload_api_fqdn = "${var.upload_api_fqdn}"
   ingest_api_key = "${var.ingest_api_key}"

--- a/terraform/modules/upload-service/dns.tf
+++ b/terraform/modules/upload-service/dns.tf
@@ -1,0 +1,31 @@
+data "aws_route53_zone" "deployment_stage" {
+  name = "${var.parent_zone_domain_name}."
+}
+
+data "aws_acm_certificate" "deployment_stage" {
+  domain   = "*.${var.parent_zone_domain_name}"
+  statuses = ["ISSUED"]
+  types = ["AMAZON_ISSUED"]
+  most_recent = true
+}
+
+resource "aws_api_gateway_domain_name" "upload" {
+  certificate_arn = "${data.aws_acm_certificate.deployment_stage.arn}"
+  domain_name     = "${var.upload_api_fqdn}"
+
+  endpoint_configuration {
+    types = ["EDGE"]
+  }
+}
+
+resource "aws_route53_record" "upload" {
+  name    = "${aws_api_gateway_domain_name.upload.domain_name}"
+  type    = "A"
+  zone_id = "${data.aws_route53_zone.deployment_stage.id}"
+
+  alias {
+    evaluate_target_health = false
+    name                   = "${aws_api_gateway_domain_name.upload.cloudfront_domain_name}"
+    zone_id                = "${aws_api_gateway_domain_name.upload.cloudfront_zone_id}"
+  }
+}

--- a/terraform/modules/upload-service/dns.tf
+++ b/terraform/modules/upload-service/dns.tf
@@ -18,6 +18,15 @@ resource "aws_api_gateway_domain_name" "upload" {
   }
 }
 
+data "external" "api_gateway" {
+  program = ["${path.cwd}/../../../scripts/get_api_id", "--json"]
+
+  query = {
+    api_gateway_name = "upload.lambdas.api_server"
+    lambda_name = "${aws_lambda_function.upload_api_lambda.function_name}"
+  }
+}
+
 resource "aws_route53_record" "upload" {
   name    = "${aws_api_gateway_domain_name.upload.domain_name}"
   type    = "A"
@@ -28,4 +37,10 @@ resource "aws_route53_record" "upload" {
     name                   = "${aws_api_gateway_domain_name.upload.cloudfront_domain_name}"
     zone_id                = "${aws_api_gateway_domain_name.upload.cloudfront_zone_id}"
   }
+}
+
+resource "aws_api_gateway_base_path_mapping" "status_api" {
+  api_id      = "${lookup(data.external.api_gateway.result, "api_id")}"
+  stage_name  = "${var.deployment_stage}"
+  domain_name = "${aws_api_gateway_domain_name.upload.domain_name}"
 }

--- a/terraform/modules/upload-service/variables.tf
+++ b/terraform/modules/upload-service/variables.tf
@@ -22,11 +22,18 @@ variable "staging_bucket_arn" {
   type = "string"
 }
 
-// API Lambda
+// DNS
+
+variable "parent_zone_domain_name" {
+  type = "string"
+}
 
 variable "upload_api_fqdn" {
   type = "string"
 }
+
+// API Lambda
+
 variable "ingest_api_key" {
   type = "string"
 }


### PR DESCRIPTION
## Need
* As an operator of the upload service
* I want a subdomain created for the upload API as part of deployment
* so that I don't have to create it by hand

## Approach
This PR retrieves the zone ID for the parent DNS domain and the certificate for that domain and creates a Route53 A Record alias tied to an API Gateway domain name.

## Rollout plan
This is confirmed to work for `dev`, but the `parent_zone_domain_name` variable has not yet been added to `terraform.tfvars` for the `integration`, `staging`, and `prod` deployment environments.

As the code changes propagate through the deployment stages, operators will have to take the following steps to roll out the changes:

1. The build will fail since the following resources have not yet been imported in the state file.
    1. `aws_api_gateway_domain_name.upload`
    1. `aws_route53_record.upload`
    1. `aws_api_gateway_base_path_mapping.status_api`
1. Import
    1. `cd terraform/envs/<deployment_environment>`
    1. `terraform init`
    1. `make retrieve-vars`
    1. Add `parent_zone_domain_name = "<deployment_stage>.data.humancellatlas.org"` to `terraform.tfvars`
    1. `make upload-vars`
    1. `make plan` You should see that terraform wants to create the following resources
        1. `module.upload-service.aws_api_gateway_base_path_mapping.status_api`
        1. `module.upload-service.aws_api_gateway_domain_name.upload`
        1. `module.upload-service.aws_route53_record.upload`
    1. Import the existing resources, replacing `<deployment_stage>` with your deployment stage and `<zone_id>` with the zone id of the parent domain in Route53
        1. `terraform import terraform import module.upload-service.aws_api_gateway_base_path_mapping.status_api upload.<deployment_stage>.data.humancellatlas.org/`
        1. `terraform import module.upload-service.aws_api_gateway_domain_name.upload upload.<deployment_stage>.data.humancellatlas.org`
        1. ` terraform import module.upload-service.aws_route53_record.upload <zone_id>_upload.<deployment_stage>.data.humancellatlas.org_A`
1. Rerun the deployment