### PR TITLE
Rewrite functional tests to use the hca.upload library (#355)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ chalice >= 1.1.1, < 1.2.0
 coverage==4.5.1
 domovoi == 1.5.7
 flake8==3.5.0
-hca>=4.9.0, <5.0.0
+hca>=5.1.0, <6
 moto==1.3.7
 python-dateutil==2.6.1
 -r requirements.txt

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -132,7 +132,7 @@ FixtureFile.register(name='10241MB_file',
                      })
 
 FixtureFile.register(name='metadata_file.json',
-                     contents={'test_obj': 'test_obj'},
+                     contents='{"test_obj": "test_obj"}',
                      checksums={
                          "s3_etag": "98b3a7471805e97a493c0e42763abe14",
                          "sha1": "f3c6f383698e3abf90721e9705d99d065708d405",

--- a/tests/functional/test_upload_service.py
+++ b/tests/functional/test_upload_service.py
@@ -8,6 +8,7 @@ import unittest
 import boto3
 import requests
 
+from hca.upload import UploadService
 from upload.common.database_orm import DbUploadArea, DbFile, DbChecksum, DbValidation, DBSessionMaker
 from upload.common.upload_config import UploadConfig
 from .waitfor import WaitFor
@@ -25,130 +26,94 @@ class TestUploadService(unittest.TestCase):
         self.db_session_maker = DBSessionMaker()
 
     def setUp(self):
-        _start_time = time.time()
-        self.api_url = f"https://{os.environ['API_HOST']}/v1"
+        self.test_start_time = time.time()
         self.upload_config = UploadConfig()
-        self.auth_headers = {'Api-Key': self.upload_config.api_key}
-        self.deployment_stage = os.environ['DEPLOYMENT_STAGE']
+        self.upload_client = UploadService(
+            deployment_stage=os.environ['DEPLOYMENT_STAGE'],
+            api_token=self.upload_config.api_key
+        )
         self.upload_area_uuid = "deadbeef-dead-dead-dead-%012d" % random.randint(0, 999999999999)
-        self.verbose = True
-        _end_time = time.time()
-        print(f"Total startup time: {_end_time - _start_time} seconds.")
-
-    def test__put_file__successful(self):
-        # Test variables
-        _start_time = time.time()
-        _metadata_file = FixtureFile.factory('metadata_file.json')
-
-        # Run test
-        print(f"\n\nUsing environment {self.deployment_stage} at URL {self.api_url}.\n")
+        print("")
         self._execute_create_upload_area()
-        self._execute_put_file_using_api(_metadata_file)
-        self._verify_file_was_checksummed_inline(_metadata_file)
+        print("\tstartup time: %0.02f seconds." % (time.time() - self.test_start_time))
 
+    def tearDown(self):
+        test_end_time = time.time()
+        print("\t%s took %0.02f seconds." % (self._testMethodName, test_end_time - self.test_start_time))
         self._execute_delete_upload_area()
+        print("\tteardown time: %0.02f seconds." % (time.time() - test_end_time))
 
-        _end_time = time.time()
-        print(f"Total test_upload__small_file__successful time: {_end_time - _start_time} seconds.")
+        # All tests are formatted into 2-3 sections separated by blank lines:
+        #
+        #   Setup preconditions (optional)
+        #
+        #   Do the thing we are testing
+        #
+        #   Test the thing was done
 
-    def test__upload_small_file__successful(self):
-        # Test variables
-        _start_time = time.time()
-        _small_file = FixtureFile.factory('small_file')
+    def test_store_file_using_api(self):
+        metadata_file = FixtureFile.factory('metadata_file.json')
 
-        # Run test
-        print(f"\n\nUsing environment {self.deployment_stage} at URL {self.api_url}.\n")
-        self._execute_create_upload_area()
+        self.upload_area.store_file(filename=metadata_file.name,
+                                    file_content=metadata_file.contents,
+                                    content_type='application/json; dcp-type=metadata')
 
-        self._execute_upload_file_using_cli(_small_file.path)
-        self._verify_file_was_checksummed_inline(_small_file)
+        self._verify_file_was_checksummed_inline(metadata_file)  # Implicitly tests file was created.
 
-        _validation_id = self._execute_validate_file(_small_file)
-        self._verify_file_validation_status(_validation_id)  # default parameters checks for success in validation
+    def test_store_file_using_cli(self):
+        """ Tests storing of a file directly in S3, then notification of Upload via REST API """
+        small_file = FixtureFile.factory('small_file')
 
-        self._execute_forget_upload_area()
-        self._execute_delete_upload_area()
+        self._execute_upload_file_using_cli(small_file.path)
 
-        _end_time = time.time()
-        print(f"Total test_upload__small_file__successful time: {_end_time - _start_time} seconds.")
+        self._verify_file_was_checksummed_inline(small_file)  # Implicitly tests file was created.
 
-    def test__upload_large_file__successful(self):
-        # Test variables
-        _start_time = time.time()
-        _large_file = FixtureFile.factory('10241MB_file')
+    def test_store_file_using_cli__with_large_file__triggers_batch_checksumming(self):
+        large_file = FixtureFile.factory('10241MB_file')
 
-        # Run test
-        print(f"\n\nUsing environment {self.deployment_stage} at URL {self.api_url}.\n")
-        self._execute_create_upload_area()
+        self._execute_upload_file_using_cli(large_file.url)
 
-        self._execute_upload_file_using_cli(_large_file.url)
-        self._verify_file_is_checksummed_via_batch(_large_file)
+        self._verify_file_is_checksummed_via_batch(large_file)
 
-        self._execute_forget_upload_area()
-        self._execute_delete_upload_area()
+    def test_validate_file__with_valid_file__reports_validation_results(self):
+        small_file = FixtureFile.factory('small_file')
+        self.upload_area.store_file(filename=small_file.name,
+                                    file_content=small_file.contents,
+                                    content_type='application/json; dcp-type=data')
 
-        _end_time = time.time()
-        print(f"Total test__upload_large_file__successful time: {_end_time - _start_time} seconds.")
+        response = self.upload_area.validate_files(file_list=[small_file.name],
+                                                   validator_image="humancellatlas/upload-validator-example:14")
+
+        validation_id = response['validation_id']
+        self._wait_for_validation_to_complete(validation_id)
+        self._verify_file_validation_status(validation_id)  # default parameters checks for success in validation
 
     def test__upload_invalid_file__validation_result_shows_invalid_state(self):
-        # Test variables
-        _start_time = time.time()
-        _invalid_file = FixtureFile.factory('small_invalid_file')
+        invalid_file = FixtureFile.factory('small_invalid_file')
+        self.upload_area.store_file(filename=invalid_file.name,
+                                    file_content=invalid_file.contents,
+                                    content_type='application/json; dcp-type=data')
 
-        # Run test
-        print(f"\n\nUsing environment {self.deployment_stage} at URL {self.api_url}.\n")
-        self._execute_create_upload_area()
+        response = self.upload_area.validate_files(file_list=[invalid_file.name],
+                                                   validator_image="humancellatlas/upload-validator-example:14")
 
-        self._execute_upload_file_using_cli(_invalid_file.path)
-        self._verify_file_was_checksummed_inline(_invalid_file)
-
-        _validation_id = self._execute_validate_file(_invalid_file)
-
+        validation_id = response['validation_id']
+        self._wait_for_validation_to_complete(validation_id)
         # Verify that the validation result of the file is invalid. This is designated by an exit code of 1 and the
         # presence of an error message saying that file is invalid.
-        self._verify_file_validation_status(_validation_id, 1, "invalid")
-
-        self._execute_forget_upload_area()
-        self._execute_delete_upload_area()
-
-        _end_time = time.time()
-        print(
-            f"Total test__upload_invalid_file__validation_result_shows_invalid_state time: {_end_time - _start_time} "
-            f"seconds.")
+        self._verify_file_validation_status(validation_id, expected_exit_code=1, expected_error_msg="invalid")
 
     def _execute_create_upload_area(self):
-        response = self._make_request(description="CREATE UPLOAD AREA",
-                                      verb='POST',
-                                      url=f"{self.api_url}/area/{self.upload_area_uuid}",
-                                      headers=self.auth_headers,
-                                      expected_status=201)
-        data = json.loads(response)
-        self.uri = data['uri']
+        self.upload_area = self.upload_client.create_area(self.upload_area_uuid)
         self.assertEqual('UNLOCKED', self._get_upload_area_record_status())
+        print(f"\tCreated upload area {self.upload_area_uuid}")
 
     def _execute_upload_file_using_cli(self, file_location):
-        self._run_cli_command("SELECT UPLOAD AREA", ['hca', 'upload', 'select', self.uri])
-        self._run_cli_command("UPLOAD FILE USING CLI", ['hca', 'upload', 'files', file_location])
+        self._run_cli_command('hca', 'upload', 'select', str(self.upload_area.uri))
+        self._run_cli_command('hca', 'upload', 'files', file_location)
+        self._run_cli_command('hca', 'upload', 'forget', self.upload_area.uuid)
 
-    def _execute_put_file_using_api(self, test_file):
-        headers = {'Content-Type': 'application/json; dcp-type=data'}
-        headers.update(self.auth_headers)
-        self._make_request(description="VALIDATE",
-                           verb='PUT',
-                           url=f"{self.api_url}/area/{self.upload_area_uuid}/{test_file.name}",
-                           expected_status=201,
-                           headers=headers,
-                           json=test_file.contents)
-
-    def _execute_validate_file(self, test_file):
-        response = self._make_request(description="VALIDATE",
-                                      verb='PUT',
-                                      url=f"{self.api_url}/area/{self.upload_area_uuid}/{test_file.name}/validate",
-                                      expected_status=200,
-                                      headers=self.auth_headers,
-                                      json={"validator_image": "humancellatlas/upload-validator-example:14"})
-        validation_id = json.loads(response)['validation_id']
-
+    def _wait_for_validation_to_complete(self, validation_id):
         WaitFor(self._get_validation_record_status, validation_id) \
             .to_return_value('SCHEDULED', timeout_seconds=MINUTE_SEC)
 
@@ -160,24 +125,16 @@ class TestUploadService(unittest.TestCase):
         WaitFor(self._get_validation_record_status, validation_id) \
             .to_return_value('VALIDATED', timeout_seconds=MINUTE_SEC)
 
-        return validation_id
-
-    def _execute_forget_upload_area(self):
-        self._run_cli_command("FORGET UPLOAD AREA", ['hca', 'upload', 'forget', self.upload_area_uuid])
-
     def _execute_delete_upload_area(self):
-        self._make_request(description="DELETE UPLOAD AREA",
-                           verb='DELETE',
-                           url=f"{self.api_url}/area/{self.upload_area_uuid}",
-                           headers=self.auth_headers,
-                           expected_status=202)
+        print(f"\tDeleting upload area {self.upload_area.uuid}")
+        self.upload_area.delete()
         WaitFor(self._get_upload_area_record_status) \
             .to_return_value('DELETED', timeout_seconds=MINUTE_SEC)
 
     def _verify_file_was_checksummed_inline(self, test_file):
         """ For files that are smaller than 10G, we expect that the file will be check-summed inline. This means that
         there is no need to schedule a job in batch and no job id is given to the checksum record."""
-        print("VERIFYING FILE WAS CHECKSUMMED INLINE...")
+        print("\tVerifying file was checksummed inline...")
 
         WaitFor(self._get_checksum_record_status, test_file.name) \
             .to_return_value('CHECKSUMMED', timeout_seconds=300)
@@ -202,7 +159,7 @@ class TestUploadService(unittest.TestCase):
     def _verify_file_is_checksummed_via_batch(self, test_file):
         """ For files that are 10G or larger, we expect that the file will check-summed via batch. This means that it
         first will need to be scheduled and the checksum record will be given a respective job id."""
-        print("VERIFYING FILE WAS CHECKSUMMED VIA BATCH...")
+        print("\tVerifying file was checksummed via batch...")
 
         WaitFor(self._get_checksum_record_status, test_file.name) \
             .to_return_value('SCHEDULED', timeout_seconds=30)
@@ -275,25 +232,8 @@ class TestUploadService(unittest.TestCase):
         self.assertEqual(1, len(response['jobs']))
         return response['jobs'][0]['status']
 
-    def _make_request(self, description, verb, url, expected_status=None, **options):
-        print(description + ": ")
-        print(f"{verb.upper()} {url}")
-
-        method = getattr(requests, verb.lower())
-        response = method(url, **options)
-
-        print(f"-> {response.status_code}")
-        if expected_status:
-            self.assertEqual(expected_status, response.status_code)
-
-        if response.content:
-            print(response.content.decode('utf8'))
-
-        return response.content
-
-    def _run_cli_command(self, description, command, expected_returncode=0):
-        print("\n" + description + ": ")
-        print(' '.join(command))
+    def _run_cli_command(self, *command, expected_returncode=0):
+        print("\t" + ' '.join(command))
         completed_process = subprocess.run(command, stdout=None, stderr=None)
         self.assertEqual(expected_returncode, completed_process.returncode)
 

--- a/tests/functional/waitfor.py
+++ b/tests/functional/waitfor.py
@@ -39,7 +39,7 @@ class WaitFor:
 
     def _call_func(self):
         retval = self.func(*self.func_args)
-        print(f"After {self._elapsed_time()}: {self._function_signature()} returned {retval}")
+        print(f"\tafter {self._elapsed_time()}: {self._function_signature()} returned {retval}")
         return retval
 
     def _wait_until_next_check_time(self):


### PR DESCRIPTION
instead of calling the REST API directly.
Try to format test output to be more sectioned and readable.