### PR TITLE
Before uploading a file, check to see if the file has already been up…

### DIFF
--- a/tests/unit/common/test_uploaded_file.py
+++ b/tests/unit/common/test_uploaded_file.py
@@ -4,12 +4,11 @@ import uuid
 
 from sqlalchemy.orm.exc import NoResultFound
 
-from .. import UploadTestCaseUsingMockAWS
-from ... import FixtureFile
-
 from upload.common.database_orm import DBSessionMaker, DbFile
 from upload.common.upload_area import UploadArea
 from upload.common.uploaded_file import UploadedFile
+from .. import UploadTestCaseUsingMockAWS
+from ... import FixtureFile
 
 
 class TestUploadedFile(UploadTestCaseUsingMockAWS):
@@ -36,10 +35,9 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
 
     def tearDown(self):
         super().tearDown()
-        pass
 
     def test_create__creates_a_new_s3_object_and_db_record(self):
-        filename = f"file-{random.randint(0,999999999)}"
+        filename = f"file-{random.randint(0, 999999999)}"
         content_type = "application/octet-stream; dcp-type=data"
         file_content = "file1_content"
 
@@ -64,7 +62,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(self.upload_area.db_id, record.upload_area_id)
 
     def test_init__given_existing_entities__initializes_properties_correctly(self):
-        filename = f"file-{random.randint(0,999999999)}"
+        filename = f"file-{random.randint(0, 999999999)}"
         s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
         file_record = self.create_file_record(s3object)
 
@@ -82,7 +80,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(s3object.content_length, uf.size)
 
     def test_init__when_no_db_record_exists__creates_a_db_record(self):
-        filename = f"file-{random.randint(0,999999999)}"
+        filename = f"file-{random.randint(0, 999999999)}"
         s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
 
         with self.assertRaises(NoResultFound):
@@ -101,7 +99,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(self.upload_area.db_id, record.upload_area_id)
 
     def test_init__doesnt_create_db_record_if_one_already_exists(self):
-        filename = f"file-{random.randint(0,999999999)}"
+        filename = f"file-{random.randint(0, 999999999)}"
         s3_key = f"{self.upload_area_id}/{filename}"
         s3object = self.create_s3_object(s3_key)
         self.create_file_record(s3object)
@@ -113,7 +111,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(record_count_before, record_count_after)
 
     def test_from_s3_key__initializes_correctly(self):
-        filename = f"file-{random.randint(0,999999999)}"
+        filename = f"file-{random.randint(0, 999999999)}"
         s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
         file_record = self.create_file_record(s3object)
 
@@ -124,7 +122,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(file_record.id, uf.db_id)
 
     def test_from_db_id__initializes_correctly_and_figures_out_which_upload_area_to_use(self):
-        filename = f"file-{random.randint(0,999999999)}"
+        filename = f"file-{random.randint(0, 999999999)}"
         s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
         file_record = self.create_file_record(s3object)
 
@@ -136,7 +134,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(file_record.id, uf.db_id)
 
     def test_refresh__picks_up_changed_content_type(self):
-        filename = f"file-{random.randint(0,999999999)}"
+        filename = f"file-{random.randint(0, 999999999)}"
         old_content_type = "application/octet-stream"  # missing dcp-type
         new_content_type = "application/octet-stream; dcp-type=data"
         s3object = self.create_s3_object(object_key=f"{self.upload_area.uuid}/{filename}",
@@ -155,7 +153,7 @@ class TestUploadedFile(UploadTestCaseUsingMockAWS):
         self.assertEqual(new_content_type, uf.content_type)
 
     def test_checksums_setter_saves_db_record(self):
-        filename = f"file-{random.randint(0,999999999)}"
+        filename = f"file-{random.randint(0, 999999999)}"
         s3object = self.create_s3_object(f"{self.upload_area_id}/{filename}")
         file_record = self.create_file_record(s3object)
         uf = UploadedFile.from_db_id(file_record.id)

--- a/tests/unit/common/test_validation_scheduler.py
+++ b/tests/unit/common/test_validation_scheduler.py
@@ -1,12 +1,11 @@
-import uuid
 import json
+import uuid
 from unittest.mock import patch
 
+from upload.common.database import UploadDB
 from upload.common.upload_area import UploadArea
 from upload.common.uploaded_file import UploadedFile
 from upload.common.validation_scheduler import ValidationScheduler, MAX_FILE_SIZE_IN_BYTES
-from upload.common.database import UploadDB
-
 from .. import UploadTestCaseUsingMockAWS
 
 

--- a/upload/common/upload_area.py
+++ b/upload/common/upload_area.py
@@ -143,7 +143,7 @@ class UploadArea:
         self._db_update()
 
     def ls(self):
-        return {'files': self._file_list()}
+        return {'files': [file.info() for file in self._file_list()]}
 
     def lock(self):
         self.status = "LOCKED"
@@ -168,19 +168,21 @@ class UploadArea:
         clientside_checksums = checksum_handler.get_checksum_metadata_tag()
         file = UploadedFile.create(upload_area=self, checksums=clientside_checksums, name=filename,
                                    content_type=str(media_type), data=content)
-        checksum_id = str(uuid.uuid4())
-        checksum_event = ChecksumEvent(file_id=file.db_id,
-                                       checksum_id=checksum_id,
-                                       status="CHECKSUMMING")
-        checksum_event.create_record()
+        if file.recently_uploaded:
+            checksum_id = str(uuid.uuid4())
+            checksum_event = ChecksumEvent(file_id=file.db_id,
+                                           checksum_id=checksum_id,
+                                           status="CHECKSUMMING")
+            checksum_event.create_record()
 
-        checksums = DssChecksums(s3_object=file.s3object)
-        checksums.compute(report_progress=True)
-        checksums.save_as_tags_on_s3_object()
-        file.checksums = dict(checksums)
+            checksums = DssChecksums(s3_object=file.s3object)
+            checksums.compute(report_progress=True)
+            checksums.save_as_tags_on_s3_object()
+            file.checksums = dict(checksums)
 
-        checksum_event.status = "CHECKSUMMED"
-        checksum_event.update_record()
+            checksum_event.status = "CHECKSUMMED"
+            checksum_event.update_record()
+
         return file
 
     def add_to_delete_sqs(self):
@@ -262,13 +264,14 @@ class UploadArea:
         return results[0][0]
 
     def _file_list(self):
+        """ Returns a list UploadedFile objects representing files that exists in the current bucket."""
         file_list = []
         paginator = S3.meta.client.get_paginator('list_objects')
         for page in paginator.paginate(Bucket=self.bucket_name, Prefix=self.key_prefix):
             if 'Contents' in page:
                 for o in page['Contents']:
                     file = UploadedFile.from_s3_key(self, o['Key'])
-                    file_list.append(file.info())
+                    file_list.append(file)
         return file_list
 
     def _empty_upload_area(self):


### PR DESCRIPTION
…loaded by checking its filename and checksums and if it has, skip uploading it and return the file that already exists.